### PR TITLE
Support sending sessionDataKey as flowId.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AbstractAuthenticatorAdapter.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AbstractAuthenticatorAdapter.java
@@ -156,12 +156,7 @@ public abstract class AbstractAuthenticatorAdapter extends AbstractApplicationAu
     @Override
     public String getContextIdentifier(HttpServletRequest request) {
 
-        String state = request.getParameter("state");
-        if (state != null) {
-            return state.split(",")[0];
-        } else {
-            return null;
-        }
+        return request.getParameter("flowId");
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/util/AuthenticatedUserBuilder.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.U
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.model.AuthenticatedUserData;
+import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -38,6 +39,8 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.LOCAL;
 
 /**
  * This is responsible for building the authenticated user object from the authenticated user data.
@@ -86,7 +89,7 @@ public class AuthenticatedUserBuilder {
 
     private AuthenticatorAdapterConstants.UserType resolveIdpType() {
 
-        return context.getExternalIdP() == null ?
+        return LOCAL.equals(context.getExternalIdP().getIdPName()) ?
                 AuthenticatorAdapterConstants.UserType.LOCAL : AuthenticatorAdapterConstants.UserType.FEDERATED;
     }
 
@@ -127,10 +130,18 @@ public class AuthenticatedUserBuilder {
         Map<ClaimMapping, String> userAttributes = new HashMap<>();
 
             for (AuthenticatedUserData.Claim claim : user.getUser().getClaims()) {
-            userAttributes.put(ClaimMapping.build(
-                    claim.getUri(), claim.getUri(), null, false), claim.getValue());
+            userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValue());
         }
         return userAttributes;
+    }
+
+    private ClaimMapping buildClaimMapping(String claimUri) {
+        ClaimMapping claimMapping = new ClaimMapping();
+        Claim claim = new Claim();
+        claim.setClaimUri(claimUri);
+        claimMapping.setRemoteClaim(claim);
+        claimMapping.setLocalClaim(claim);
+        return claimMapping;
     }
 
     private AbstractUserStoreManager resolveUserStoreManager(AuthenticationContext context, String userStoreDomain)


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22715

Improve getContextIdentifier method of the authenticator to continue the authentication flow by given `flowId=<sessionDataKey> param in the returing url.