### PR TITLE
Improve custom authentication adapter authentication action response processing

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessor.java
@@ -89,12 +89,13 @@ public class AuthenticationResponseProcessor implements ActionExecutionResponseP
                         Availability.UNAVAILABLE, Validity.INVALID, errorMessage));
                 throw new ActionExecutionResponseProcessorException(errorMessage);
             }
-            context.setSubject(context.getLastAuthenticatedUser());
+        } else {
+            AuthenticatedUserData authenticatedUserData =
+                    (AuthenticatedUserData) actionInvocationSuccessResponse.getData();
+            AuthenticatedUser authenticatedUser = new AuthenticatedUserBuilder(authenticatedUserData, context)
+                    .buildAuthenticateduser();
+            context.setSubject(authenticatedUser);
         }
-        AuthenticatedUserData authenticatedUserData = (AuthenticatedUserData) actionInvocationSuccessResponse.getData();
-        AuthenticatedUser authenticatedUser = new AuthenticatedUserBuilder(authenticatedUserData, context)
-                .buildAuthenticateduser();
-        context.setSubject(authenticatedUser);
 
         return new SuccessStatus.Builder().setResponseContext(eventContext).build();
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessor.java
@@ -82,20 +82,20 @@ public class AuthenticationResponseProcessor implements ActionExecutionResponseP
         AuthenticatorPropertyConstants.AuthenticationType authType = (AuthenticatorPropertyConstants.AuthenticationType)
                 eventContext.get(AuthenticatorAdapterConstants.AUTH_TYPE);
         if (actionInvocationSuccessResponse.getData() == null) {
-            if (AuthenticatorPropertyConstants.AuthenticationType.IDENTIFICATION.equals(authType)) {
-                String errorMessage = "The user field is missing in the authentication action response. This field " +
-                        "is required for IDENTIFICATION authentication.";
-                DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult("",
-                        Availability.UNAVAILABLE, Validity.INVALID, errorMessage));
-                throw new ActionExecutionResponseProcessorException(errorMessage);
+            if (AuthenticatorPropertyConstants.AuthenticationType.VERIFICATION.equals(authType)) {
+                return new SuccessStatus.Builder().setResponseContext(eventContext).build();
             }
-        } else {
-            AuthenticatedUserData authenticatedUserData =
-                    (AuthenticatedUserData) actionInvocationSuccessResponse.getData();
-            AuthenticatedUser authenticatedUser = new AuthenticatedUserBuilder(authenticatedUserData, context)
-                    .buildAuthenticateduser();
-            context.setSubject(authenticatedUser);
+            String errorMessage = "The user field is missing in the authentication action response. This field " +
+                    "is required for IDENTIFICATION authentication.";
+            DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult("",
+                    Availability.UNAVAILABLE, Validity.INVALID, errorMessage));
+            throw new ActionExecutionResponseProcessorException(errorMessage);
         }
+        AuthenticatedUserData authenticatedUserData =
+                (AuthenticatedUserData) actionInvocationSuccessResponse.getData();
+        AuthenticatedUser authenticatedUser = new AuthenticatedUserBuilder(authenticatedUserData, context)
+                .buildAuthenticateduser();
+        context.setSubject(authenticatedUser);
 
         return new SuccessStatus.Builder().setResponseContext(eventContext).build();
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessor.java
@@ -81,10 +81,14 @@ public class AuthenticationResponseProcessor implements ActionExecutionResponseP
                 AuthenticatorAdapterConstants.AUTH_CONTEXT);
         AuthenticatorPropertyConstants.AuthenticationType authType = (AuthenticatorPropertyConstants.AuthenticationType)
                 eventContext.get(AuthenticatorAdapterConstants.AUTH_TYPE);
+
+        if (AuthenticatorPropertyConstants.AuthenticationType.VERIFICATION.equals(authType)) {
+            return new SuccessStatus.Builder().setResponseContext(eventContext).build();
+        }
+
+        /* The authentication type is set by the authenticator adapter, and for IDENTIFICATION authentication type,
+         providing user data in the action authentication is mandatory.*/
         if (actionInvocationSuccessResponse.getData() == null) {
-            if (AuthenticatorPropertyConstants.AuthenticationType.VERIFICATION.equals(authType)) {
-                return new SuccessStatus.Builder().setResponseContext(eventContext).build();
-            }
             String errorMessage = "The user field is missing in the authentication action response. This field " +
                     "is required for IDENTIFICATION authentication.";
             DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult("",

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/model/AuthenticationActionExecutionResult.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/model/AuthenticationActionExecutionResult.java
@@ -70,7 +70,7 @@ public class AuthenticationActionExecutionResult {
      * Enum to represent the validity of the field value in the authentication action response.
      */
     public enum Validity {
-        VALID, INVALID
+        VALID, INVALID, IGNORED
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/util/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/util/AuthenticatorAdapterConstants.java
@@ -27,6 +27,7 @@ public class AuthenticatorAdapterConstants {
     public static final String WSO2_CLAIM_DIALECT = "http://wso2.org/claims";
     public static final String EXTERNAL_ID_CLAIM = "http://wso2.org/claims/externalID";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
+    public static final String GROUP_CLAIM = "http://wso2.org/claims/groups";
     public static final String AUTH_REQUEST = "authenticationRequest";
     public static final String AUTH_RESPONSE = "authenticationResponse";
     public static final String AUTH_CONTEXT = "authContext";

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/util/DiagnosticLogger.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/util/DiagnosticLogger.java
@@ -56,6 +56,20 @@ public class DiagnosticLogger {
     }
 
     /**
+     * Logs the diagnostic log for the ignored data in the authentication action response with SUCCESS status.
+     *
+     * @param executionResult The authentication action response execution result.
+     * @param userType        The user type.
+     */
+    public static void logSuccessResponseWithIgnoredData(
+            AuthenticationActionExecutionResult executionResult, String userType) {
+
+        logResponseExecutionResult(executionResult, DiagnosticLog.ResultStatus.SUCCESS,
+                String.format("The %s field in the authentication action response is not applicable for %s user. " +
+                        "Hence, this field will be ignored.", executionResult.getFieldName(), userType));
+    }
+
+    /**
      * Logs the diagnostic log for the authentication action response executing with INCOMPLETE status.
      *
      * @param executionResult The authentication action response execution result.

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
@@ -349,56 +349,37 @@ public class AuthenticationResponseProcessorTest {
 
         return new Object[][] {
                 {authContextWithNoUser, authSuccessResponseWithoutUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingUserId},
-                {authContextWithNoUser, authSuccessResponseWithoutUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingUserId},
+                        errorMessageForMissingUserId},
                 {authContextWithNoUser, authSuccessResponseWithMissMatchUserName,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingMissMatchUserName},
-                {authContextWithNoUser, authSuccessResponseWithMissMatchUserName,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingMissMatchUserName},
+                        errorMessageForMissingMissMatchUserName},
                 {authContextWithNoUser, authSuccessResponseWithNonExistingUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForNonExistingUserId},
-                {authContextWithNoUser, authSuccessResponseWithNonExistingUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForNonExistingUserId},
+                        errorMessageForNonExistingUserId},
                 {authContextWithNoUser, authSuccessResponseWithNoUser,
-                        AuthenticationType.IDENTIFICATION, errorMessageForNoUserDate},
+                        errorMessageForNoUserDate},
 
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithoutUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingUserId},
-                {authContextWithLocalUserFromFirstStep, authSuccessResponseWithoutUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingUserId},
+                        errorMessageForMissingUserId},
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithMissMatchUserName,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingMissMatchUserName},
-                {authContextWithLocalUserFromFirstStep, authSuccessResponseWithMissMatchUserName,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingMissMatchUserName},
+                        errorMessageForMissingMissMatchUserName},
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithNonExistingUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForNonExistingUserId},
-                {authContextWithLocalUserFromFirstStep, authSuccessResponseWithNonExistingUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForNonExistingUserId},
+                        errorMessageForNonExistingUserId},
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithNoUser,
-                        AuthenticationType.IDENTIFICATION, errorMessageForNoUserDate},
+                        errorMessageForNoUserDate},
 
                 {authContextWithFedUserFromFirstStep, authSuccessResponseWithoutUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingUserId},
-                {authContextWithFedUserFromFirstStep, authSuccessResponseWithoutUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingUserId},
+                        errorMessageForMissingUserId},
                 {authContextWithFedUserFromFirstStep, authSuccessResponseWithMissMatchUserName,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingMissMatchUserName},
-                {authContextWithFedUserFromFirstStep, authSuccessResponseWithMissMatchUserName,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingMissMatchUserName},
+                        errorMessageForMissingMissMatchUserName},
                 {authContextWithFedUserFromFirstStep, authSuccessResponseWithNonExistingUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForNonExistingUserId},
-                {authContextWithFedUserFromFirstStep, authSuccessResponseWithNonExistingUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForNonExistingUserId},
+                        errorMessageForNonExistingUserId},
                 {authContextWithFedUserFromFirstStep, authSuccessResponseWithNoUser,
-                        AuthenticationType.IDENTIFICATION, errorMessageForNoUserDate}
+                        errorMessageForNoUserDate}
         };
     }
 
     @Test(dataProvider = "getSuccessInvalidResponsesForLocalUsers")
     public void testProcessSuccessResponseWithInvalidResponsesForLocalUsers(AuthenticationContext context,
-            ActionInvocationSuccessResponse actionInvocationSuccessResponse, AuthenticationType authType,
-            String errorMessage)
+            ActionInvocationSuccessResponse actionInvocationSuccessResponse, String errorMessage)
             throws Exception {
 
         if (actionInvocationSuccessResponse.getData() != null) {
@@ -406,7 +387,7 @@ public class AuthenticationResponseProcessorTest {
                     ((AuthenticatedUserData) actionInvocationSuccessResponse.getData()).getUser().getUserStore());
         }
         Map<String, Object> eventContext = new TestEventContextBuilder().buildEventContext(
-                request, response, context, authType);
+                request, response, context, AuthenticationType.IDENTIFICATION);
         when(mockedActionExecutorService.execute(any(), any(), any(), any())).thenReturn(
                 new SuccessStatus.Builder().setResponseContext(eventContext).build());
         context.setCurrentStep(2);
@@ -489,22 +470,29 @@ public class AuthenticationResponseProcessorTest {
                         new AuthenticatedUserData(authUserNoUserId));
         String errorMessageForMissingUserId = "The userId field is missing in the authentication action response.";
 
+        ExternallyAuthenticatedUser authUserWithInvalidGroupName = new ExternallyAuthenticatedUser();
+        authUserWithInvalidGroupName.setGroups(new ArrayList<>(List.of("group,1", "group2")));
+        ActionInvocationSuccessResponse authSuccessResponseWithInvalidGroupName = TestActionInvocationResponseBuilder
+                .buildAuthenticationSuccessResponse(
+                        new ArrayList<>(), new AuthenticatedUserData(authUserWithInvalidGroupName));
+        String errorMessageForNoInvalidGroupName = String.format("The character %s is not allowed in names of groups," +
+                " as it is used internally to separate multiple groups.", FrameworkUtils.getMultiAttributeSeparator());
+
         return new Object[][] {
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithoutUserId,
-                        AuthenticationType.IDENTIFICATION, errorMessageForMissingUserId},
-                {authContextWithLocalUserFromFirstStep, authSuccessResponseWithoutUserId,
-                        AuthenticationType.VERIFICATION, errorMessageForMissingUserId}
+                        errorMessageForMissingUserId},
+                {authContextWithLocalUserFromFirstStep, authSuccessResponseWithInvalidGroupName,
+                        errorMessageForNoInvalidGroupName}
         };
     }
 
     @Test(dataProvider = "getSuccessInvalidResponsesForFederatedUsers")
     public void testProcessSuccessResponseWithInvalidResponsesForFederatedUsers(AuthenticationContext context,
-            ActionInvocationSuccessResponse actionInvocationSuccessResponse, AuthenticationType authType,
-            String errorMessage)
+            ActionInvocationSuccessResponse actionInvocationSuccessResponse, String errorMessage)
             throws Exception {
 
         Map<String, Object> eventContext = new TestEventContextBuilder().buildEventContext(
-                request, response, context, authType);
+                request, response, context, AuthenticationType.IDENTIFICATION);
         when(mockedActionExecutorService.execute(any(), any(), any(), any())).thenReturn(
                 new SuccessStatus.Builder().setResponseContext(eventContext).build());
         context.setCurrentStep(2);

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
@@ -45,6 +45,7 @@ import org.wso2.carbon.identity.application.authentication.framework.context.Aut
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.model.AuthenticatedUserData;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.AuthenticatorAdapterConstants;
@@ -113,6 +114,7 @@ public class AuthenticationResponseProcessorTest {
     private UserStoreManager mockedUserStoreManager;
     private AuthenticationResponseProcessor authenticationResponseProcessor;
     private MockedStatic<LoggerUtils> loggerUtils;
+    private MockedStatic<FrameworkUtils> frameworkUtils;
 
     @BeforeClass
     public void setUp() throws Exception {
@@ -242,8 +244,7 @@ public class AuthenticationResponseProcessorTest {
 
         ActionInvocationSuccessResponse authSuccessResponseWithNoUser = TestActionInvocationResponseBuilder
                 .buildAuthenticationSuccessResponse(
-                        new ArrayList<>(),
-                        null);
+                        new ArrayList<>(), null);
 
         return new Object[][] {
                 {authContextWithNoUser, authSuccessResponseWithAuthUser, AuthenticationType.IDENTIFICATION},
@@ -342,8 +343,7 @@ public class AuthenticationResponseProcessorTest {
 
         ActionInvocationSuccessResponse authSuccessResponseWithNoUser = TestActionInvocationResponseBuilder
                 .buildAuthenticationSuccessResponse(
-                        new ArrayList<>(),
-                        null);
+                        new ArrayList<>(), null);
         String errorMessageForNoUserDate = "The user field is missing in the authentication action " +
                 "response. This field is required for IDENTIFICATION authentication.";
 
@@ -595,6 +595,9 @@ public class AuthenticationResponseProcessorTest {
 
         loggerUtils = mockStatic(LoggerUtils.class);
         loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
+
+        frameworkUtils = mockStatic(FrameworkUtils.class);
+        frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
     }
 
     private void createExpectedAuthenticatedUsers() {


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/22715

With this PR following improvements will added.
- Enable sending groups for federated authenticators in the authentication action response.
- Allow 2FA local authenticators to send authentication action responses without user data.