### PR TITLE
Change user/idp to user/userIdentitySource in the request event.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 public class AuthenticatingUser extends User {
 
-    private String idp;
+    private String userIdentitySource;
     private String sub;
     private final List<UserClaim> claims = new ArrayList<>();
 
@@ -44,7 +44,8 @@ public class AuthenticatingUser extends User {
     public AuthenticatingUser(String id, AuthenticatedUser user) {
         super(id);
         sub = user.getAuthenticatedSubjectIdentifier();
-        idp = user.isFederatedUser() ? AuthenticatorAdapterConstants.FED_IDP : AuthenticatorAdapterConstants.LOCAL_IDP;
+        userIdentitySource = user.isFederatedUser() ?
+                AuthenticatorAdapterConstants.FED_IDP : AuthenticatorAdapterConstants.LOCAL_IDP;
 
         Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
         if (userAttributes != null) {
@@ -60,12 +61,12 @@ public class AuthenticatingUser extends User {
         return claims;
     }
 
-    public void setIdp(String idp) {
-        this.idp = idp;
+    public void setUserIdentitySource(String userIdentitySource) {
+        this.userIdentitySource = userIdentitySource;
     }
 
-    public String getIdp() {
-        return idp;
+    public String getUserIdentitySource() {
+        return userIdentitySource;
     }
 
     public void setSub(String sub) {

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -168,7 +168,7 @@ public class AuthenticationRequestBuilderTest {
         AuthenticatingUser actualAuthenticatingUser = (AuthenticatingUser) actualAuthenticationEvent.getUser();
         AuthenticatingUser expectedUser = (AuthenticatingUser) expectedEvent.getUser();
         Assert.assertEquals(actualAuthenticatingUser.getId(), expectedUser.getId());
-        Assert.assertEquals(actualAuthenticatingUser.getIdp(), expectedUser.getIdp());
+        Assert.assertEquals(actualAuthenticatingUser.getUserIdentitySource(), expectedUser.getUserIdentitySource());
         Assert.assertEquals(actualAuthenticatingUser.getSub(), expectedUser.getSub());
         Assert.assertEquals(actualAuthenticatingUser.getClaims().size(), expectedUser.getClaims().size());
         Assert.assertEquals(actualAuthenticationEvent.getOrganization().getId(), AuthenticatedUserConstants.ORG_ID);
@@ -201,9 +201,9 @@ public class AuthenticationRequestBuilderTest {
 
         AuthenticatingUser authenticatingUser = new AuthenticatingUser(user.getUserId());
         if (user.isFederatedUser()) {
-            authenticatingUser.setIdp(AuthenticatorAdapterConstants.FED_IDP);
+            authenticatingUser.setUserIdentitySource(AuthenticatorAdapterConstants.FED_IDP);
         } else {
-            authenticatingUser.setIdp(AuthenticatorAdapterConstants.LOCAL_IDP);
+            authenticatingUser.setUserIdentitySource(AuthenticatorAdapterConstants.LOCAL_IDP);
         }
         authenticatingUser.setSub(user.getAuthenticatedSubjectIdentifier());
         return authenticatingUser;


### PR DESCRIPTION
Issue:



Current `user` in the request to the external authentication service.
```
 "user": {
     "id": "9f1ab106-ce85-46b1-8f41-6a071b54eb56",
     "idp": "LOCAL/FEDERATED",
     "groups": [],
     "claims": [
       {
         "uri": "http://wso2.org/claims/username",
         "value": "johnd@gmail.com"
       }
     ]
   }
```

Modified `user` in the request to the external authentication service.
```
 "user": {
     "id": "9f1ab106-ce85-46b1-8f41-6a071b54eb56",
     "userIdentitySource": "LOCAL/FEDERATED",
     "groups": [],
     "claims": [
       {
         "uri": "http://wso2.org/claims/username",
         "value": "johnd@gmail.com"
       }
     ]
   }
```