### PR TITLE
Remove isIdfInitiatedFromAuthenticator from context.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AbstractAuthenticatorAdapter.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AbstractAuthenticatorAdapter.java
@@ -47,6 +47,8 @@ import java.util.Optional;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.RequestParams.IS_IDF_INITIATED_FROM_AUTHENTICATOR;
+
 /**
  * This class holds the external custom authentication.
  */
@@ -76,6 +78,13 @@ public abstract class AbstractAuthenticatorAdapter extends AbstractApplicationAu
             if (context.isLogoutRequest()) {
                 return AuthenticatorFlowStatus.SUCCESS_COMPLETED;
             }
+
+            /* When an identifier is initiated, the isIdfInitiatedFromAuthenticator property is set but never removed.
+             During login, if this property exists, the current authenticator is set to null, overriding any selection.
+             For custom authenticators, this causes unintended resets. To fix this, we remove the property in
+             handleRequestFlow, ensuring the correct authenticator persists.
+             */
+            context.removeProperty(IS_IDF_INITIATED_FROM_AUTHENTICATOR);
 
             FlowContext flowContext = FlowContext.create();
             flowContext.add(AuthenticatorAdapterConstants.AUTH_REQUEST, request);


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23168

When an Identifier is first initiated by an authenticator, the property isIdfInitiatedFromAuthenticator is set in the context but never removed. To support the "Choose Different Option" functionality with these authenticators, the system checks for this property when processing a login request from the login page. If the property is present, the current authenticator in the context is set to null. Consequently, the current authenticator is overridden to null, even if a different authenticator is selected later.
For custom authenticators, we expect the current authenticator to be properly set during the handleRequestFlow to be used handleResponseFlow. Even that current authenticator is set, due to above behavior it reset to null. 

To address this, when a custom authenticator reaches the handleRequestFlow, we remove the isIdfInitiatedFromAuthenticator property as it is no longer relevant. This fix ensures the correct authenticator is set and resolves the linked issue.