### PR TITLE
Improve resolving default userStore for local users.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
@@ -38,6 +38,8 @@ public class AuthenticatorAdapterConstants {
     public static final String FED_IDP = "FEDERATED";
     public static final String EXECUTION_STATUS_PROP_NAME = "actionExecutionStatus";
 
+    public static final String DEFAULT_USER_STORE_CONFIG_PATH = "Actions.Types.Authentication.DefaultUserStore";
+
     /**
      * User Type of the authenticated user communicated with the external authentication service.
      */


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23211

Provide capability to configure default userstore for local users authenticating via the external service when the userstore domain is not specified in the response from the external authenticator.