### PR TITLE
Use LastAuthenticatedUser to retrieve authenticated user from the context

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
@@ -83,7 +83,7 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
 
     private Event getEvent(AuthenticationContext context) throws ActionExecutionRequestBuilderException {
 
-        AuthenticatedUser currentAuthenticatedUser = context.getSubject();
+        AuthenticatedUser currentAuthenticatedUser = context.getLastAuthenticatedUser();
         String tenantDomain = context.getTenantDomain();
 
         AuthenticationRequestEvent.Builder eventBuilder = new AuthenticationRequestEvent.Builder();

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationResponseProcessor.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationResponseProcessor.java
@@ -83,6 +83,7 @@ public class AuthenticationResponseProcessor implements ActionExecutionResponseP
                 AuthenticatorAdapterConstants.AUTH_TYPE, AuthenticatorPropertyConstants.AuthenticationType.class);
 
         if (AuthenticatorPropertyConstants.AuthenticationType.VERIFICATION.equals(authType)) {
+            context.setSubject(context.getLastAuthenticatedUser());
             return new SuccessStatus.Builder().setResponseContext(flowContext.getContextData()).build();
         }
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23317

For B2B scenrios the context.subject becomes null, even through there is a authenticated user from the previous step. Therefore, change retriveing already authenticated user from the context.getLastAuthenticatedUser().