### PR TITLE
Remove authenticated tenant domain from the user.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
@@ -89,7 +89,7 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
         AuthenticationRequestEvent.Builder eventBuilder = new AuthenticationRequestEvent.Builder();
         eventBuilder.tenant(new Tenant(String.valueOf(IdentityTenantUtil.getTenantId(tenantDomain)), tenantDomain));
         if (currentAuthenticatedUser != null) {
-            eventBuilder.user(getUserForEventBuilder(currentAuthenticatedUser));
+            eventBuilder.user(getUserForEventBuilder(currentAuthenticatedUser, tenantDomain));
             eventBuilder.organization(getOrganizationForEventBuilder(currentAuthenticatedUser));
             eventBuilder.userStore(new UserStore(currentAuthenticatedUser.getUserStoreDomain()));
         }
@@ -100,11 +100,11 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
         return eventBuilder.build();
     }
 
-    private User getUserForEventBuilder(AuthenticatedUser authenticatedUser)
+    private User getUserForEventBuilder(AuthenticatedUser authenticatedUser, String tenantDomain)
             throws ActionExecutionRequestBuilderException {
 
         try {
-            return new AuthenticatingUser(authenticatedUser.getUserId(), authenticatedUser);
+            return new AuthenticatingUser(authenticatedUser.getUserId(), authenticatedUser, tenantDomain);
         } catch (UserIdNotFoundException e) {
             throw new ActionExecutionRequestBuilderException("User ID not found for current authenticated user.", e);
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.internal.model;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.action.execution.api.model.User;
 import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -41,9 +42,9 @@ public class AuthenticatingUser extends User {
         super(id);
     }
 
-    public AuthenticatingUser(String id, AuthenticatedUser user) {
+    public AuthenticatingUser(String id, AuthenticatedUser user, String tenantDomain) {
         super(id);
-        sub = user.getAuthenticatedSubjectIdentifier();
+        sub = StringUtils.replace(user.getAuthenticatedSubjectIdentifier(), "@" + tenantDomain, StringUtils.EMPTY);
         userIdentitySource = user.isFederatedUser() ?
                 AuthenticatorAdapterConstants.FED_IDP : AuthenticatorAdapterConstants.LOCAL_IDP;
 


### PR DESCRIPTION
With this PR, the tenant domain will be removed from the sub attribute of the user object sending in the request to external authentication service.

`testuser@<tenant_domain>` -> `testuser`