### PR TITLE
Add userStore domain to the thread local.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -40,6 +40,7 @@ import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 import org.wso2.carbon.user.core.common.User;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.HashMap;
 import java.util.List;
@@ -280,6 +281,7 @@ public class AuthenticatedUserBuilder {
             } else {
                 userStoreDomainName = getDefaultUserStore();
             }
+            UserCoreUtil.setDomainInThreadLocal(userStoreDomainName);
             userStoreManager = (AbstractUserStoreManager) userRealm.getUserStoreManager()
                     .getSecondaryUserStoreManager(userStoreDomainName);
         } catch (UserStoreException e) {


### PR DESCRIPTION
Issue:
- https://github.com/wso2-enterprise/asgardeo-product/issues/29412

When creating local authenticated user with method `AuthenticatedUser.createLocalAuthenticatedUserFromSubjectIdentifier`, the userstore domain of the user is trying to retrieve from the threadLocal [1]. Therefore, with this PR the userStore domain is set to the threadlocal

[1]. https://github.com/wso2/carbon-identity-framework/blob/master/components/authentication-framework/org.wso2.carbon.identity.application.authentication.framework/src/main/java/org/wso2/carbon/identity/application/authentication/framework/model/AuthenticatedUser.java#L154