### PR TITLE
Support multi-value user claims for custom authentication extension

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
@@ -30,6 +30,8 @@ public class AuthenticatorAdapterConstants {
     public static final String EXTERNAL_ID_CLAIM = "http://wso2.org/claims/externalID";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String GROUP_CLAIM = "http://wso2.org/claims/groups";
+    public static final String ROLES_CLAIM = "http://wso2.org/claims/roles";
+    public static final String ADDRESS_CLAIM = "http://wso2.org/claims/addresses";
     public static final String AUTH_REQUEST = "authenticationRequest";
     public static final String AUTH_RESPONSE = "authenticationResponse";
     public static final String AUTH_CONTEXT = "authContext";

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.internal.constant;
 
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
-
 /**
  * This class holds the constants related to the authentication adapter.
  */
@@ -41,7 +39,6 @@ public class AuthenticatorAdapterConstants {
     public static final String LOCAL_IDP = "LOCAL";
     public static final String FED_IDP = "FEDERATED";
     public static final String EXECUTION_STATUS_PROP_NAME = "actionExecutionStatus";
-    public static final String MULTI_ATTR_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
     public static final String DEFAULT_USER_STORE_CONFIG_PATH = "Actions.Types.Authentication.DefaultUserStore";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.internal.constant;
 
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+
 /**
  * This class holds the constants related to the authentication adapter.
  */
@@ -37,6 +39,7 @@ public class AuthenticatorAdapterConstants {
     public static final String LOCAL_IDP = "LOCAL";
     public static final String FED_IDP = "FEDERATED";
     public static final String EXECUTION_STATUS_PROP_NAME = "actionExecutionStatus";
+    public static final String MULTI_ATTR_SEPARATOR = FrameworkUtils.getMultiAttributeSeparator();
 
     public static final String DEFAULT_USER_STORE_CONFIG_PATH = "Actions.Types.Authentication.DefaultUserStore";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
@@ -3,10 +3,9 @@ package org.wso2.carbon.identity.application.authenticator.adapter.internal.mode
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.wso2.carbon.identity.action.execution.api.model.ResponseData;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 
 import java.util.List;
-
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_ATTR_SEPARATOR;
 
 /**
  * This class holds the data of the authenticated user, which are presented in response from the external
@@ -112,7 +111,7 @@ public class AuthenticatedUserData implements ResponseData {
         public String getValueAsString() {
 
             if (value instanceof List) {
-                return String.join(MULTI_ATTR_SEPARATOR, (List<String>) value);
+                return String.join(FrameworkUtils.getMultiAttributeSeparator(), (List<String>) value);
             }
             return (String) value;
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
@@ -94,7 +94,15 @@ public class AuthenticatedUserData implements ResponseData {
         @JsonCreator
         public Claim(
                 @JsonProperty("uri") String uri,
-                @JsonProperty("value") Object value) {
+                @JsonProperty("value") String value) {
+            this.uri = uri;
+            this.value = value;
+        }
+
+        @JsonCreator
+        public Claim(
+                @JsonProperty("uri") String uri,
+                @JsonProperty("value") List<String> value) {
             this.uri = uri;
             this.value = value;
         }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
@@ -104,7 +104,12 @@ public class AuthenticatedUserData implements ResponseData {
             return uri;
         }
 
-        public String getValue() {
+        public Object getValue() {
+
+            return value;
+        }
+
+        public String getValueAsString() {
 
             if (value instanceof List) {
                 return String.join(MULTI_ATTR_SEPARATOR, (List<String>) value);

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatedUserData.java
@@ -6,6 +6,8 @@ import org.wso2.carbon.identity.action.execution.api.model.ResponseData;
 
 import java.util.List;
 
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_ATTR_SEPARATOR;
+
 /**
  * This class holds the data of the authenticated user, which are presented in response from the external
  * authentication service.
@@ -85,7 +87,7 @@ public class AuthenticatedUserData implements ResponseData {
         private String uri;
 
         @JsonProperty("value")
-        private String value;
+        private Object value;
 
         public Claim() {
         }
@@ -93,7 +95,7 @@ public class AuthenticatedUserData implements ResponseData {
         @JsonCreator
         public Claim(
                 @JsonProperty("uri") String uri,
-                @JsonProperty("value") String value) {
+                @JsonProperty("value") Object value) {
             this.uri = uri;
             this.value = value;
         }
@@ -103,7 +105,11 @@ public class AuthenticatedUserData implements ResponseData {
         }
 
         public String getValue() {
-            return value;
+
+            if (value instanceof List) {
+                return String.join(MULTI_ATTR_SEPARATOR, (List<String>) value);
+            }
+            return (String) value;
         }
     }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.internal.model;
 
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.identity.action.execution.api.model.User;
 import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
@@ -27,6 +28,9 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_ATTR_SEPARATOR;
 
 /**
  * This class holds the authenticated user object which is communicated to the external authentication service.
@@ -36,6 +40,9 @@ public class AuthenticatingUser extends User {
     private String userIdentitySource;
     private String sub;
     private final List<UserClaim> claims = new ArrayList<>();
+
+    public static final String ADDRESS = "address";
+    public static final String GROUPS = "groups";
 
     public AuthenticatingUser(String id) {
         super(id);
@@ -52,6 +59,11 @@ public class AuthenticatingUser extends User {
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
                 String claimUri = entry.getKey().getLocalClaim().getClaimUri();
                 String claimValue = entry.getValue();
+                if (isMultiValuedAttribute(claimUri, claimValue)) {
+                    String[] attributeValues = claimValue.split(Pattern.quote(MULTI_ATTR_SEPARATOR));
+                    claims.add(new UserClaim(claimUri, attributeValues));
+                    continue;
+                }
                 claims.add(new UserClaim(claimUri, claimValue));
             }
         }
@@ -75,6 +87,20 @@ public class AuthenticatingUser extends User {
 
     public String getSub() {
         return sub;
+    }
+
+    private boolean isMultiValuedAttribute(String claimKey, String claimValue) {
+
+        // Address claim contains multi attribute separator but its not a multi valued attribute.
+        if (claimKey.equals(ADDRESS)) {
+            return false;
+        }
+        // To format the groups claim to always return as an array, we should consider single group as
+        // multi value attribute.
+        if (claimKey.equals(GROUPS)) {
+            return true;
+        }
+        return StringUtils.contains(claimValue, MULTI_ATTR_SEPARATOR);
     }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -26,10 +26,12 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.const
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_ATTR_SEPARATOR;
 
 /**
@@ -39,39 +41,46 @@ public class AuthenticatingUser extends User {
 
     private String userIdentitySource;
     private String sub;
-    private final List<UserClaim> claims = new ArrayList<>();
-
-    public static final String ADDRESS = "address";
-    public static final String GROUPS = "groups";
-
-    public AuthenticatingUser(String id) {
-        super(id);
-    }
 
     public AuthenticatingUser(String id, AuthenticatedUser user) {
-        super(id);
+
+        super(buildUser(id, user));
         sub = user.getAuthenticatedSubjectIdentifier();
         userIdentitySource = user.isFederatedUser() ?
                 AuthenticatorAdapterConstants.FED_IDP : AuthenticatorAdapterConstants.LOCAL_IDP;
+    }
+
+    private static User.Builder buildUser(String id, AuthenticatedUser user) {
+
+        User.Builder userBuilder = new User.Builder(id);
 
         Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
+        List<UserClaim> userClaimList = new ArrayList<>();
         if (userAttributes != null) {
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
                 String claimUri = entry.getKey().getLocalClaim().getClaimUri();
+                if (claimUri.equals(AuthenticatorAdapterConstants.GROUP_CLAIM)) {
+                    userBuilder.groups(Arrays.asList(entry.getValue().split(Pattern.quote(MULTI_ATTR_SEPARATOR))));
+                    continue;
+                } else if (claimUri.equals(AuthenticatorAdapterConstants.ROLES_CLAIM)) {
+                    /* Since we are not supporting role management with the custom authenticator in the initial phase,
+                     we are ignoring it. */
+                    continue;
+                }
+
                 String claimValue = entry.getValue();
                 if (isMultiValuedAttribute(claimUri, claimValue)) {
                     String[] attributeValues = claimValue.split(Pattern.quote(MULTI_ATTR_SEPARATOR));
-                    claims.add(new UserClaim(claimUri, attributeValues));
+                    userClaimList.add(new UserClaim(claimUri, attributeValues));
                     continue;
                 }
-                claims.add(new UserClaim(claimUri, claimValue));
+                userClaimList.add(new UserClaim(claimUri, claimValue));
             }
         }
+        userBuilder.claims(userClaimList);
+        return userBuilder;
     }
 
-    public List<UserClaim> getClaims() {
-        return claims;
-    }
 
     public void setUserIdentitySource(String userIdentitySource) {
         this.userIdentitySource = userIdentitySource;
@@ -89,16 +98,11 @@ public class AuthenticatingUser extends User {
         return sub;
     }
 
-    private boolean isMultiValuedAttribute(String claimKey, String claimValue) {
+    private static boolean isMultiValuedAttribute(String claimKey, String claimValue) {
 
         // Address claim contains multi attribute separator but its not a multi valued attribute.
-        if (claimKey.equals(ADDRESS)) {
+        if (claimKey.equals(ADDRESS_CLAIM)) {
             return false;
-        }
-        // To format the groups claim to always return as an array, we should consider single group as
-        // multi value attribute.
-        if (claimKey.equals(GROUPS)) {
-            return true;
         }
         return StringUtils.contains(claimValue, MULTI_ATTR_SEPARATOR);
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.identity.action.execution.api.model.User;
 import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 
@@ -32,7 +33,6 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_ATTR_SEPARATOR;
 
 /**
  * This class holds the authenticated user object which is communicated to the external authentication service.
@@ -53,6 +53,7 @@ public class AuthenticatingUser extends User {
     private static User.Builder buildUser(String id, AuthenticatedUser user) {
 
         User.Builder userBuilder = new User.Builder(id);
+        String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
 
         Map<ClaimMapping, String> userAttributes = user.getUserAttributes();
         List<UserClaim> userClaimList = new ArrayList<>();
@@ -60,7 +61,7 @@ public class AuthenticatingUser extends User {
             for (Map.Entry<ClaimMapping, String> entry : userAttributes.entrySet()) {
                 String claimUri = entry.getKey().getLocalClaim().getClaimUri();
                 if (claimUri.equals(AuthenticatorAdapterConstants.GROUP_CLAIM)) {
-                    userBuilder.groups(Arrays.asList(entry.getValue().split(Pattern.quote(MULTI_ATTR_SEPARATOR))));
+                    userBuilder.groups(Arrays.asList(entry.getValue().split(Pattern.quote(multiAttributeSeparator))));
                     continue;
                 } else if (claimUri.equals(AuthenticatorAdapterConstants.ROLES_CLAIM)) {
                     /* Since we are not supporting role management with the custom authenticator in the initial phase,
@@ -69,8 +70,8 @@ public class AuthenticatingUser extends User {
                 }
 
                 String claimValue = entry.getValue();
-                if (isMultiValuedAttribute(claimUri, claimValue)) {
-                    String[] attributeValues = claimValue.split(Pattern.quote(MULTI_ATTR_SEPARATOR));
+                if (isMultiValuedAttribute(claimUri, claimValue, multiAttributeSeparator)) {
+                    String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                     userClaimList.add(new UserClaim(claimUri, attributeValues));
                     continue;
                 }
@@ -98,13 +99,13 @@ public class AuthenticatingUser extends User {
         return sub;
     }
 
-    private static boolean isMultiValuedAttribute(String claimKey, String claimValue) {
+    private static boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
 
         // Address claim contains multi attribute separator but its not a multi valued attribute.
         if (claimKey.equals(ADDRESS_CLAIM)) {
             return false;
         }
-        return StringUtils.contains(claimValue, MULTI_ATTR_SEPARATOR);
+        return StringUtils.contains(claimValue, multiAttributeSeparator);
     }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -214,14 +214,14 @@ public class AuthenticatedUserBuilder {
 
         if (claimValue instanceof List) {
             for (String value : (List<String>) claimValue) {
-                validateMultiAttributeSeparatorContainsInValue(value);
+                validateIfValueContainsMultiAttributeSeparator(value);
             }
         } else {
-            validateMultiAttributeSeparatorContainsInValue((String) claimValue);
+            validateIfValueContainsMultiAttributeSeparator((String) claimValue);
         }
     }
 
-    private void validateMultiAttributeSeparatorContainsInValue(String value)
+    private void validateIfValueContainsMultiAttributeSeparator(String value)
             throws ActionExecutionResponseProcessorException {
 
         if (StringUtils.contains(value, FrameworkUtils.getMultiAttributeSeparator())) {

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -47,9 +47,11 @@ import java.util.List;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.LOCAL;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.DEFAULT_USER_STORE_CONFIG_PATH;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.EXTERNAL_ID_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ROLES_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.USERNAME_CLAIM;
 
 /**
@@ -179,20 +181,52 @@ public class AuthenticatedUserBuilder {
         throw new ActionExecutionResponseProcessorException(errorMessage);
     }
 
-    private Map<ClaimMapping, String> resolveUserNameAndClaimsFromResponse() {
+    private Map<ClaimMapping, String> resolveUserNameAndClaimsFromResponse()
+            throws ActionExecutionResponseProcessorException {
 
         Map<ClaimMapping, String> userAttributes = new HashMap<>();
         for (AuthenticatedUserData.Claim claim : userFromResponse.getUser().getClaims()) {
+            validateClaimValue(claim.getUri(), claim.getValue());
             if (GROUP_CLAIM.equals(claim.getUri())) {
                 ignoreGroupsInClaimsInResponse();
                 continue;
+            } else if (ROLES_CLAIM.equals(claim.getUri())) {
+                continue;
             }
-            userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValue());
+            userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValueAsString());
             if (USERNAME_CLAIM.equals(claim.getUri())) {
-                usernameFromResponse = claim.getValue();
+                usernameFromResponse = claim.getValueAsString();
             }
         }
         return userAttributes;
+    }
+
+    private void validateClaimValue(String claimUri, Object claimValue)
+            throws ActionExecutionResponseProcessorException {
+
+        if (ADDRESS_CLAIM.equals(claimUri)) {
+            return;
+        }
+
+        if (claimValue instanceof List) {
+            for (String value : (List<String>) claimValue) {
+                validateMultiAttributeSeparatorContainsInValue(value);
+            }
+        } else {
+            validateMultiAttributeSeparatorContainsInValue((String) claimValue);
+        }
+    }
+
+    private void validateMultiAttributeSeparatorContainsInValue(String value)
+            throws ActionExecutionResponseProcessorException {
+
+        if (StringUtils.contains(value, FrameworkUtils.getMultiAttributeSeparator())) {
+            String errorMessage = String.format("The character %s is not allowed in claim values, as it is " +
+                    "used internally to separate multiple values.", FrameworkUtils.getMultiAttributeSeparator());
+            DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
+                    "claims", Availability.AVAILABLE, Validity.INVALID, errorMessage));
+            throw new ActionExecutionResponseProcessorException(errorMessage);
+        }
     }
 
     private void resolveGroupsForFederatedUser(Map<ClaimMapping, String> claimMappings)

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -191,6 +191,8 @@ public class AuthenticatedUserBuilder {
                 ignoreGroupsInClaimsInResponse();
                 continue;
             } else if (ROLES_CLAIM.equals(claim.getUri())) {
+                /* Since we are not supporting role management with the custom authenticator in the initial phase,
+                 we are ignoring it. */
                 continue;
             }
             userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValueAsString());
@@ -205,6 +207,8 @@ public class AuthenticatedUserBuilder {
             throws ActionExecutionResponseProcessorException {
 
         if (ADDRESS_CLAIM.equals(claimUri)) {
+            /* The ADDRESS claim is not validated for multi-value separator characters since it is internally treated
+             as a single-valued claim. */
             return;
         }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -193,8 +193,7 @@ public class AuthenticatedUserBuilder {
             } else if (ROLES_CLAIM.equals(claim.getUri())) {
                 DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
                         "claims/" + ROLES_CLAIM, Availability.AVAILABLE, Validity.INVALID,
-                        "Currently we are not supporting role management with the custom authenticator, " +
-                                "hence ignoring role claim."));
+                        "Currently setting roles for the authenticated user is not allowed."));
                 continue;
             }
             userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValueAsString());

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -191,8 +191,10 @@ public class AuthenticatedUserBuilder {
                 ignoreGroupsInClaimsInResponse();
                 continue;
             } else if (ROLES_CLAIM.equals(claim.getUri())) {
-                /* Since we are not supporting role management with the custom authenticator in the initial phase,
-                 we are ignoring it. */
+                DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
+                        "claims/" + ROLES_CLAIM, Availability.AVAILABLE, Validity.INVALID,
+                        "Currently we are not supporting role management with the custom authenticator, " +
+                                "hence ignoring role claim."));
                 continue;
             }
             userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValueAsString());

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -55,7 +55,6 @@ import org.wso2.carbon.identity.organization.management.service.exception.Organi
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -162,9 +161,6 @@ public class AuthenticationRequestBuilderTest {
                 userWithMultiValueClaims, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
         AuthenticationRequestEvent expectedEventWithMultiValueClaims =
                 getExpectedEvent(userWithMultiValueClaims, false);
-        Arrays.stream(USER_GROUP_VALUE.split(SEPARATOR)).forEach(group -> {
-            expectedEventWithMultiValueClaims.getUser().addGroup(group);
-        });
 
         return new Object[][]{
                 {flowContextForNoUser, getExpectedEvent(null, true), true},

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -34,9 +34,11 @@ import org.wso2.carbon.identity.action.execution.api.model.FlowContext;
 import org.wso2.carbon.identity.action.execution.api.model.Operation;
 import org.wso2.carbon.identity.action.execution.api.model.Organization;
 import org.wso2.carbon.identity.action.execution.api.model.Tenant;
+import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.AuthenticationRequestBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.component.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
@@ -44,6 +46,8 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.model
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestFlowContextBuilder;
+import org.wso2.carbon.identity.application.common.model.Claim;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
@@ -51,6 +55,8 @@ import org.wso2.carbon.identity.organization.management.service.exception.Organi
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -59,19 +65,30 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.WSO2_CLAIM_DIALECT;
 import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder.AuthenticatedUserConstants;
 
 public class AuthenticationRequestBuilderTest {
 
     private AuthenticationRequestBuilder authenticationRequestBuilder;
     private MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic;
+    private MockedStatic<FrameworkUtils> frameworkUtils;
     private MockedStatic<LoggerUtils> loggerUtils;
     private MockedStatic<OrganizationManagementUtil> organizationManagementUtil;
+    private static final String SEPARATOR = ",";
 
     private static final String TENANT_DOMAIN_TEST = "carbon.super";
     private static final int TENANT_ID_TEST = -1234;
     private static final String ORG_NAME_TEST = "subOrg";
     private static final String ORG_ID_TEST = "12345";
+    private static final String USER_CLAIM_URI = WSO2_CLAIM_DIALECT + "/customUri";
+    private static final String USER_CLAIM_VALUE = "customValue";
+    private static final String USER_MULTI_VALUE_CLAIM_URI = WSO2_CLAIM_DIALECT + "/multiValueUri";
+    private static final String USER_MULTI_CLAIM_VALUE = "value1, value2";
+    private static final String USER_GROUP_VALUE = "group1, group2";
+    private static final String ADDRESS = "5th Avenue, New York, USA";
     Map<String, String> headers = Map.of("header-1", "value-1", "header-2", "value-2");
     Map<String, String> parameters = Map.of("param-1", "value-1", "param-2", "value-2");
     ArrayList<AuthHistory> authHistory;
@@ -89,6 +106,8 @@ public class AuthenticationRequestBuilderTest {
         identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
         identityTenantUtilMockedStatic.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN_TEST))
                 .thenReturn(TENANT_ID_TEST);
+        frameworkUtils = mockStatic(FrameworkUtils.class);
+        frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(SEPARATOR);
 
         organizationManagementUtil = mockStatic(OrganizationManagementUtil.class);
         organizationManagementUtil.when(() ->
@@ -105,6 +124,7 @@ public class AuthenticationRequestBuilderTest {
     public void tearDown() {
 
         identityTenantUtilMockedStatic.close();
+        frameworkUtils.close();
         organizationManagementUtil.close();
         loggerUtils.close();
     }
@@ -132,7 +152,19 @@ public class AuthenticationRequestBuilderTest {
         AuthenticatedUser fedUser = TestAuthenticatedTestUserBuilder.createAuthenticatedUser(
                 AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
         FlowContext flowContextForFedUser = new TestFlowContextBuilder().buildFlowContext(
-                fedUser, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);;
+                fedUser, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
+
+        // Custom authenticator engaging in 2nd step of authentication flow with multi-value claims.
+        AuthenticatedUser userWithMultiValueClaims = TestAuthenticatedTestUserBuilder.createAuthenticatedUser(
+                AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
+        userWithMultiValueClaims.setUserAttributes(buildUserAttributes());
+        FlowContext flowContextForUserWithMultiValueClaims = new TestFlowContextBuilder().buildFlowContext(
+                userWithMultiValueClaims, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
+        AuthenticationRequestEvent expectedEventWithMultiValueClaims =
+                getExpectedEvent(userWithMultiValueClaims, false);
+        Arrays.stream(USER_GROUP_VALUE.split(SEPARATOR)).forEach(group -> {
+            expectedEventWithMultiValueClaims.getUser().addGroup(group);
+        });
 
         return new Object[][]{
                 {flowContextForNoUser, getExpectedEvent(null, true), true},
@@ -140,7 +172,8 @@ public class AuthenticationRequestBuilderTest {
                 {flowContextForLocalUser, getExpectedEvent(localUser, true), true},
                 {flowContextForLocalUser, getExpectedEvent(localUser, false), false},
                 {flowContextForFedUser, getExpectedEvent(fedUser, true), true},
-                {flowContextForFedUser, getExpectedEvent(fedUser, false), false}};
+                {flowContextForFedUser, getExpectedEvent(fedUser, false), false},
+                {flowContextForUserWithMultiValueClaims, expectedEventWithMultiValueClaims, false}};
     }
 
     @Test(dataProvider = "flowContextDataProvider")
@@ -185,6 +218,19 @@ public class AuthenticationRequestBuilderTest {
         Assert.assertEquals(actualAuthenticatingUser.getUserIdentitySource(), expectedUser.getUserIdentitySource());
         Assert.assertEquals(actualAuthenticatingUser.getSub(), expectedUser.getSub());
         Assert.assertEquals(actualAuthenticatingUser.getClaims().size(), expectedUser.getClaims().size());
+        if (!expectedUser.getClaims().isEmpty()) {
+            for (UserClaim claim : expectedUser.getClaims()) {
+                boolean claimFound = false;
+                for (UserClaim actualClaim : actualAuthenticatingUser.getClaims()) {
+                    if (claim.getUri().equals(actualClaim.getUri())) {
+                        Assert.assertEquals(actualClaim.getValue(), claim.getValue());
+                        claimFound = true;
+                        break;
+                    }
+                }
+                Assert.assertTrue(claimFound);
+            }
+        }
         if (expectedEvent.getOrganization() == null) {
             Assert.assertNull(actualAuthenticationEvent.getOrganization());
         } else {
@@ -222,7 +268,7 @@ public class AuthenticationRequestBuilderTest {
 
     private static AuthenticatingUser createAuthenticatingUser(AuthenticatedUser user) throws UserIdNotFoundException {
 
-        AuthenticatingUser authenticatingUser = new AuthenticatingUser(user.getUserId());
+        AuthenticatingUser authenticatingUser = new AuthenticatingUser(user.getUserId(), user);
         if (user.isFederatedUser()) {
             authenticatingUser.setUserIdentitySource(AuthenticatorAdapterConstants.FED_IDP);
         } else {
@@ -230,5 +276,25 @@ public class AuthenticationRequestBuilderTest {
         }
         authenticatingUser.setSub(user.getAuthenticatedSubjectIdentifier());
         return authenticatingUser;
+    }
+
+    private static Map<ClaimMapping, String> buildUserAttributes() {
+
+        Map<ClaimMapping, String> userAttributes = new HashMap<>();
+        userAttributes.put(buildClaimMapping(GROUP_CLAIM), USER_GROUP_VALUE);
+        userAttributes.put(buildClaimMapping(ADDRESS_CLAIM), ADDRESS);
+        userAttributes.put(buildClaimMapping(USER_MULTI_VALUE_CLAIM_URI), USER_MULTI_CLAIM_VALUE);
+        userAttributes.put(buildClaimMapping(USER_CLAIM_URI), USER_CLAIM_VALUE);
+        return userAttributes;
+    }
+
+    private static ClaimMapping buildClaimMapping(String claimUri) {
+
+        ClaimMapping claimMapping = new ClaimMapping();
+        Claim claim = new Claim();
+        claim.setClaimUri(claimUri);
+        claimMapping.setRemoteClaim(claim);
+        claimMapping.setLocalClaim(claim);
+        return claimMapping;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
@@ -57,6 +57,7 @@ import org.wso2.carbon.identity.application.authenticator.adapter.util.TestActio
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestFlowContextBuilder;
+import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.base.AuthenticatorPropertyConstants.AuthenticationType;
@@ -87,6 +88,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.DEFAULT_USER_STORE_CONFIG_PATH;
 
 public class AuthenticationResponseProcessorTest {
@@ -94,6 +96,7 @@ public class AuthenticationResponseProcessorTest {
     private final HttpServletRequest request = spy(HttpServletRequest.class);
     private HttpServletResponse response = spy(HttpServletResponse.class);
     private static final String TENANT_DOMAIN_TEST = "carbon.super";
+    private static final String SEPARATOR = ",";
     private static final int TENANT_ID_TEST = -1234;
     private static ArrayList<AuthHistory> authHistory;
     private static IdentityProvider fedIdp;
@@ -139,6 +142,7 @@ public class AuthenticationResponseProcessorTest {
     public void tearDown() {
 
         identityTenantUtilMockedStatic.close();
+        frameworkUtils.close();
         identityConfigParser.close();
     }
 
@@ -479,11 +483,23 @@ public class AuthenticationResponseProcessorTest {
         String errorMessageForNoInvalidGroupName = String.format("The character %s is not allowed in names of groups," +
                 " as it is used internally to separate multiple groups.", FrameworkUtils.getMultiAttributeSeparator());
 
+        ExternallyAuthenticatedUser authUserWithInvalidMultiValueClaims = new ExternallyAuthenticatedUser();
+        authUserWithInvalidMultiValueClaims.setClaims(new ArrayList<>(
+                List.of(new AuthenticatedUserData.Claim("claim1", "value1, value2"))));
+        ActionExecutionResponseContext<ActionInvocationSuccessResponse> authSuccessResponseWithInvalidMultiValueClaims =
+                TestActionInvocationResponseBuilder.buildAuthenticationSuccessResponse(
+                        new ArrayList<>(), new AuthenticatedUserData(authUserWithInvalidMultiValueClaims));
+        String errorMessageForInvalidMultiValueClaims =
+                "The character , is not allowed in claim values, as it is used internally to separate multiple values.";
+
+
         return new Object[][] {
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithoutUserId,
                         errorMessageForMissingUserId},
                 {authContextWithLocalUserFromFirstStep, authSuccessResponseWithInvalidGroupName,
-                        errorMessageForNoInvalidGroupName}
+                        errorMessageForNoInvalidGroupName},
+                {authContextWithLocalUserFromFirstStep, authSuccessResponseWithInvalidMultiValueClaims,
+                        errorMessageForInvalidMultiValueClaims}
         };
     }
 
@@ -586,7 +602,7 @@ public class AuthenticationResponseProcessorTest {
         loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
 
         frameworkUtils = mockStatic(FrameworkUtils.class);
-        frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(",");
+        frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(SEPARATOR);
 
         Map<String, Object> configMap = new HashMap<>();
         configMap.put(DEFAULT_USER_STORE_CONFIG_PATH, AuthenticatingUserConstants.USER_STORE_NAME);
@@ -611,9 +627,7 @@ public class AuthenticationResponseProcessorTest {
         userFromUserStore.setUsername(AuthenticatingUserConstants.USERNAME);
         userFromUserStore.setUserID(AuthenticatingUserConstants.USERID);
 
-        Map<ClaimMapping, String> claimsForLocalUser = new HashMap<>();
-        claimsForLocalUser.put(ClaimMapping.build("claim-1", "claim-1", null, false),
-                "value-1");
+        Map<ClaimMapping, String> claimsForLocalUser = expectedUserClaims();
         expectedLocalAuthenticatedUser = new AuthenticatedUser();
         expectedLocalAuthenticatedUser.setUserId(AuthenticatingUserConstants.USERID);
         expectedLocalAuthenticatedUser.setUserStoreDomain(AuthenticatingUserConstants.USER_STORE_NAME);
@@ -621,9 +635,7 @@ public class AuthenticationResponseProcessorTest {
         expectedLocalAuthenticatedUser.setTenantDomain(SUPER_TENANT_DOMAIN_NAME);
         expectedLocalAuthenticatedUser.setUserAttributes(claimsForLocalUser);
 
-        Map<ClaimMapping, String> claimsForFedUser = new HashMap<>();
-        claimsForFedUser.put(ClaimMapping.build("claim-1", "claim-1", "value-1", false),
-                "value-1");
+        Map<ClaimMapping, String> claimsForFedUser = expectedUserClaims();
         claimsForFedUser.put(ClaimMapping.build(AuthenticatorAdapterConstants.GROUP_CLAIM,
                         AuthenticatorAdapterConstants.GROUP_CLAIM, null, false),
                 String.join(",", groups));
@@ -642,10 +654,31 @@ public class AuthenticationResponseProcessorTest {
                 .thenReturn(expectedLocalAuthenticatedUser);
     }
 
+    private Map<ClaimMapping, String> expectedUserClaims() {
+
+        Map<ClaimMapping, String> expectedClaim = new HashMap<>();
+        expectedClaim.put(buildClaimMapping(ADDRESS_CLAIM), AuthenticatingUserConstants.ADDRESS);
+        expectedClaim.put(buildClaimMapping(AuthenticatingUserConstants.USER_CLAIM_URI),
+                AuthenticatingUserConstants.USER_CLAIM_VALUE);
+        expectedClaim.put(buildClaimMapping(AuthenticatingUserConstants.USER_MULTI_VALUE_CLAIM_URI),
+                AuthenticatingUserConstants.USER_MULTI_CLAIM_VALUE);
+        return expectedClaim;
+    }
+
     private void buildPerformableOperation() {
 
         redirectOperation = new PerformableOperation();
         redirectOperation.setOp(Operation.REDIRECT);
         redirectOperation.setUrl("http://redirect.url");
+    }
+
+    private static ClaimMapping buildClaimMapping(String claimUri) {
+
+        ClaimMapping claimMapping = new ClaimMapping();
+        Claim claim = new Claim();
+        claim.setClaimUri(claimUri);
+        claimMapping.setRemoteClaim(claim);
+        claimMapping.setLocalClaim(claim);
+        return claimMapping;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/FederatedAuthenticatorAdapterTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/FederatedAuthenticatorAdapterTest.java
@@ -57,7 +57,6 @@ import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME
 public class FederatedAuthenticatorAdapterTest {
 
     private static final String AUTHENTICATOR_NAME = "UserDefinedFederatedAuthenticator";
-    private static final String FRIENDLY_NAME = "Federated Authenticator Adapter";
     private UserDefinedFederatedAuthenticator userDefinedFederatedAuthenticator;
 
     private final HttpServletRequest request = mock(HttpServletRequest.class);
@@ -76,7 +75,6 @@ public class FederatedAuthenticatorAdapterTest {
 
         UserDefinedFederatedAuthenticatorConfig fedConfig = new UserDefinedFederatedAuthenticatorConfig();
         fedConfig.setName(AUTHENTICATOR_NAME);
-        fedConfig.setDisplayName(FRIENDLY_NAME);
         userDefinedFederatedAuthenticator = new UserDefinedFederatedAuthenticator(fedConfig);
 
         mockedActionExecutorService = mock(ActionExecutorService.class);
@@ -95,7 +93,7 @@ public class FederatedAuthenticatorAdapterTest {
     @Test
     public void testGetFriendlyName() {
 
-        Assert.assertEquals(userDefinedFederatedAuthenticator.getFriendlyName(), FRIENDLY_NAME);
+        Assert.assertEquals(userDefinedFederatedAuthenticator.getFriendlyName(), AUTHENTICATOR_NAME);
     }
 
     @Test

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestActionInvocationResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestActionInvocationResponseBuilder.java
@@ -32,7 +32,10 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.model
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 
 public class TestActionInvocationResponseBuilder {
 
@@ -100,7 +103,6 @@ public class TestActionInvocationResponseBuilder {
 
     public static class ExternallyAuthenticatedUser extends AuthenticatedUserData.User {
 
-        AuthenticatedUserData.Claim claim1 = new AuthenticatedUserData.Claim("claim-1", "value-1");
         AuthenticatedUserData.Claim  userNameClaim = new AuthenticatedUserData.Claim(
                 AuthenticatorAdapterConstants.USERNAME_CLAIM, AuthenticatingUserConstants.USERNAME);
 
@@ -115,7 +117,7 @@ public class TestActionInvocationResponseBuilder {
             userStore = new AuthenticatedUserData.UserStore(
                     AuthenticatingUserConstants.USER_STORE_ID, AuthenticatingUserConstants.USER_STORE_NAME);
             groups = new ArrayList<>();
-            claims = new ArrayList<>(List.of(claim1, userNameClaim));
+            claims = buildUserClaims();
         }
 
         public void setId(String id) {
@@ -162,6 +164,18 @@ public class TestActionInvocationResponseBuilder {
 
             claims.removeIf(claim -> AuthenticatorAdapterConstants.USERNAME_CLAIM.equals(claim.getUri()));
             claims.add(new AuthenticatedUserData.Claim(AuthenticatorAdapterConstants.USERNAME_CLAIM, userName));
+        }
+
+        private ArrayList<AuthenticatedUserData.Claim> buildUserClaims() {
+
+            return new ArrayList<>(List.of(
+                    userNameClaim,
+                    new AuthenticatedUserData.Claim(ADDRESS_CLAIM, AuthenticatingUserConstants.ADDRESS),
+                    new AuthenticatedUserData.Claim(
+                            AuthenticatingUserConstants.USER_CLAIM_URI, AuthenticatingUserConstants.USER_CLAIM_VALUE),
+                    new AuthenticatedUserData.Claim(AuthenticatingUserConstants.USER_MULTI_VALUE_CLAIM_URI,
+                            Arrays.asList(AuthenticatingUserConstants.USER_MULTI_CLAIM_VALUE
+                                    .split(AuthenticatingUserConstants.SEPARATOR)))));
         }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestAuthenticationAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestAuthenticationAdapterConstants.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.util;
 
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.WSO2_CLAIM_DIALECT;
+
 /**
  * This class holds the constants related to the authentication adapter.
  */
@@ -29,6 +31,12 @@ public class TestAuthenticationAdapterConstants {
         public static final String USER_STORE_NAME = "testUserStore";
         public static final String USER_STORE_ID = "userStoreId";
         public static final String USERNAME = "TestUser";
+        public static final String USER_CLAIM_URI = WSO2_CLAIM_DIALECT + "/customUri";
+        public static final String USER_CLAIM_VALUE = "customValue";
+        public static final String USER_MULTI_VALUE_CLAIM_URI = WSO2_CLAIM_DIALECT + "/multiValueUri";
+        public static final String USER_MULTI_CLAIM_VALUE = "value1, value2";
+        public static final String ADDRESS = "5th Avenue, New York, USA";
+        public static final String SEPARATOR = ",";
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         </identity.application.auth.adapter.package.export.version>
 
         <servlet-api.version>2.5</servlet-api.version>
-        <carbon.identity.framework.version>7.8.3</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.50-SNAPSHOT</carbon.identity.framework.version>
         <testng.version>7.10.1</testng.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <mockito.version>5.3.1</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
         </identity.application.auth.adapter.package.export.version>
 
         <servlet-api.version>2.5</servlet-api.version>
-        <carbon.identity.framework.version>7.8.50-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.58</carbon.identity.framework.version>
         <testng.version>7.10.1</testng.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <mockito.version>5.3.1</mockito.version>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23408

Improve the `UserClaim` model class to support sending and receiving multi-value user attributes in requests and responses to the external service.

Single valued:
```
"claims": [
        {
          "uri": "http://wso2.org/claims/emailaddress",
          "value": "bob@newdomain.com"
        }
      ],
```

Multi valued:
```
"claims": [
        {
          "uri": "http://wso2.org/claims/emailaddress",
          "value": ["bob@newdomain.com", "bob.work@domain.com"]
        }
      ],
```