### PR TITLE
Improve multi-value claims handling.

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>org.wso2.carbon.identity.base</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.user.core</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/component/AuthenticatorAdapterDataHolder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/component/AuthenticatorAdapterDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.application.authenticator.adapter.internal.component;
 
 import org.wso2.carbon.identity.action.execution.api.service.ActionExecutorService;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -31,6 +32,7 @@ public class AuthenticatorAdapterDataHolder {
     private ActionExecutorService actionExecutorService;
     private OrganizationManager organizationManager;
     private RealmService realmService;
+    private ClaimMetadataManagementService claimManagementService;
 
     private AuthenticatorAdapterDataHolder() {
 
@@ -99,5 +101,25 @@ public class AuthenticatorAdapterDataHolder {
     public void setRealmService(RealmService realmService) {
 
         this.realmService = realmService;
+    }
+
+    /**
+     * Get the ClaimMetadataManagementService.
+     *
+     * @return ClaimMetadataManagementService instance.
+     */
+    public ClaimMetadataManagementService getClaimManagementService() {
+
+        return claimManagementService;
+    }
+
+    /**
+     * Set the ClaimMetadataManagementService.
+     *
+     * @param claimManagementService ClaimMetadataManagementService instance.
+     */
+    public void setClaimManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        this.claimManagementService = claimManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/component/AuthenticatorAdapterServiceComponent.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/component/AuthenticatorAdapterServiceComponent.java
@@ -35,6 +35,7 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.Authe
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.AuthenticationRequestBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.AuthenticationResponseProcessor;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.UserDefinedAuthenticatorServiceImpl;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -125,5 +126,23 @@ public class AuthenticatorAdapterServiceComponent {
 
         log.debug("Unregistering the Realm Service in AuthenticatorAdapterServiceComponent.");
         AuthenticatorAdapterDataHolder.getInstance().setRealmService(null);
+    }
+
+    @Reference(
+            name = "claim.metadata.management.service",
+            service = org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetClaimMetadataManagementService")
+    protected void setClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        AuthenticatorAdapterDataHolder.getInstance().setClaimManagementService(claimManagementService);
+        log.debug("ClaimMetadataManagementService set in AuthenticatorAdapterServiceComponent.");
+    }
+
+    protected void unsetClaimMetadataManagementService(ClaimMetadataManagementService claimManagementService) {
+
+        AuthenticatorAdapterDataHolder.getInstance().setClaimManagementService(null);
+        log.debug("ClaimMetadataManagementService unset in AuthenticatorAdapterServiceComponent.");
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
@@ -25,11 +25,10 @@ public class AuthenticatorAdapterConstants {
 
     public static final String AUTHENTICATOR_NAME = "AbstractAuthenticatorAdapter";
     public static final String WSO2_CLAIM_DIALECT = "http://wso2.org/claims";
-    public static final String EXTERNAL_ID_CLAIM = "http://wso2.org/claims/externalID";
+    public static final String EXTERNAL_ID_CLAIM = "http://wso2.org/claims/externalid";
     public static final String USERNAME_CLAIM = "http://wso2.org/claims/username";
     public static final String GROUP_CLAIM = "http://wso2.org/claims/groups";
     public static final String ROLES_CLAIM = "http://wso2.org/claims/roles";
-    public static final String ADDRESS_CLAIM = "http://wso2.org/claims/addresses";
     public static final String AUTH_REQUEST = "authenticationRequest";
     public static final String AUTH_RESPONSE = "authenticationResponse";
     public static final String AUTH_CONTEXT = "authContext";
@@ -39,6 +38,7 @@ public class AuthenticatorAdapterConstants {
     public static final String LOCAL_IDP = "LOCAL";
     public static final String FED_IDP = "FEDERATED";
     public static final String EXECUTION_STATUS_PROP_NAME = "actionExecutionStatus";
+    public static final String MULTI_VALUED_PROPERTY = "multiValued";
 
     public static final String DEFAULT_USER_STORE_CONFIG_PATH = "Actions.Types.Authentication.DefaultUserStore";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/constant/AuthenticatorAdapterConstants.java
@@ -38,7 +38,6 @@ public class AuthenticatorAdapterConstants {
     public static final String LOCAL_IDP = "LOCAL";
     public static final String FED_IDP = "FEDERATED";
     public static final String EXECUTION_STATUS_PROP_NAME = "actionExecutionStatus";
-    public static final String MULTI_VALUED_PROPERTY = "multiValued";
 
     public static final String DEFAULT_USER_STORE_CONFIG_PATH = "Actions.Types.Authentication.DefaultUserStore";
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,8 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
-
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_VALUED_PROPERTY;
 
 /**
  * This class holds the authenticated user object which is communicated to the external authentication service.
@@ -116,7 +115,7 @@ public class AuthenticatingUser extends User {
             if (!localClaim.isPresent()) {
                 throw new ActionExecutionRequestBuilderException("Claim not found for claim URI: " + claimKey);
             }
-            return Boolean.parseBoolean(localClaim.get().getClaimProperty(MULTI_VALUED_PROPERTY));
+            return Boolean.parseBoolean(localClaim.get().getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY));
         } catch (ClaimMetadataException e) {
             throw new ActionExecutionRequestBuilderException(
                     "Error while retrieving claim metadata for claim URI: " + claimKey, e);

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticatingUser.java
@@ -18,21 +18,26 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.internal.model;
 
-import org.apache.commons.lang3.StringUtils;
+import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.api.model.User;
 import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authenticator.adapter.internal.component.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_VALUED_PROPERTY;
 
 /**
  * This class holds the authenticated user object which is communicated to the external authentication service.
@@ -42,7 +47,7 @@ public class AuthenticatingUser extends User {
     private String userIdentitySource;
     private String sub;
 
-    public AuthenticatingUser(String id, AuthenticatedUser user) {
+    public AuthenticatingUser(String id, AuthenticatedUser user) throws ActionExecutionRequestBuilderException {
 
         super(buildUser(id, user));
         sub = user.getAuthenticatedSubjectIdentifier();
@@ -50,7 +55,8 @@ public class AuthenticatingUser extends User {
                 AuthenticatorAdapterConstants.FED_IDP : AuthenticatorAdapterConstants.LOCAL_IDP;
     }
 
-    private static User.Builder buildUser(String id, AuthenticatedUser user) {
+    private static User.Builder buildUser(String id, AuthenticatedUser user) throws
+            ActionExecutionRequestBuilderException {
 
         User.Builder userBuilder = new User.Builder(id);
         String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
@@ -70,7 +76,7 @@ public class AuthenticatingUser extends User {
                 }
 
                 String claimValue = entry.getValue();
-                if (isMultiValuedAttribute(claimUri, claimValue, multiAttributeSeparator)) {
+                if (isMultiValuedAttribute(claimUri, user.getTenantDomain())) {
                     String[] attributeValues = claimValue.split(Pattern.quote(multiAttributeSeparator));
                     userClaimList.add(new UserClaim(claimUri, attributeValues));
                     continue;
@@ -99,13 +105,22 @@ public class AuthenticatingUser extends User {
         return sub;
     }
 
-    private static boolean isMultiValuedAttribute(String claimKey, String claimValue, String multiAttributeSeparator) {
+    private static boolean isMultiValuedAttribute(String claimKey, String tenantDomain) throws
+            ActionExecutionRequestBuilderException {
 
-        // Address claim contains multi attribute separator but its not a multi valued attribute.
-        if (claimKey.equals(ADDRESS_CLAIM)) {
-            return false;
+        ClaimMetadataManagementService claimMetadataManagementService =
+                AuthenticatorAdapterDataHolder.getInstance().getClaimManagementService();
+
+        try {
+            Optional<LocalClaim> localClaim = claimMetadataManagementService.getLocalClaim(claimKey, tenantDomain);
+            if (!localClaim.isPresent()) {
+                throw new ActionExecutionRequestBuilderException("Claim not found for claim URI: " + claimKey);
+            }
+            return Boolean.parseBoolean(localClaim.get().getClaimProperty(MULTI_VALUED_PROPERTY));
+        } catch (ClaimMetadataException e) {
+            throw new ActionExecutionRequestBuilderException(
+                    "Error while retrieving claim metadata for claim URI: " + claimKey, e);
         }
-        return StringUtils.contains(claimValue, multiAttributeSeparator);
     }
 }
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -33,6 +33,9 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.model
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationActionExecutionResult.Validity;
 import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -45,12 +48,13 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.LOCAL;
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.DEFAULT_USER_STORE_CONFIG_PATH;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.EXTERNAL_ID_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_VALUED_PROPERTY;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ROLES_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.USERNAME_CLAIM;
 
@@ -186,7 +190,6 @@ public class AuthenticatedUserBuilder {
 
         Map<ClaimMapping, String> userAttributes = new HashMap<>();
         for (AuthenticatedUserData.Claim claim : userFromResponse.getUser().getClaims()) {
-            validateClaimValue(claim.getUri(), claim.getValue());
             if (GROUP_CLAIM.equals(claim.getUri())) {
                 ignoreGroupsInClaimsInResponse();
                 continue;
@@ -196,6 +199,8 @@ public class AuthenticatedUserBuilder {
                         "Currently setting roles for the authenticated user is not allowed."));
                 continue;
             }
+            Optional<LocalClaim> localClaim = getLocalClaim(claim.getUri(), context.getTenantDomain());
+            validateClaimValue(localClaim, claim.getUri(), claim.getValue());
             userAttributes.put(buildClaimMapping(claim.getUri()), claim.getValueAsString());
             if (USERNAME_CLAIM.equals(claim.getUri())) {
                 usernameFromResponse = claim.getValueAsString();
@@ -204,51 +209,59 @@ public class AuthenticatedUserBuilder {
         return userAttributes;
     }
 
-    private void validateClaimValue(String claimUri, Object claimValue)
+    private void validateClaimValue(Optional<LocalClaim> localClaim, String claimKey, Object claimValue)
             throws ActionExecutionResponseProcessorException {
 
-        if (ADDRESS_CLAIM.equals(claimUri)) {
-            /* The ADDRESS claim is not validated for multi-value separator characters since it is internally treated
-             as a single-valued claim. */
-            return;
+        if (!localClaim.isPresent()) {
+            throw new ActionExecutionResponseProcessorException("Claim not found for claim URI: " + claimKey);
         }
 
-        if (claimValue instanceof List) {
-            for (String value : (List<String>) claimValue) {
-                validateIfValueContainsMultiAttributeSeparator(value);
+        if (Boolean.parseBoolean(localClaim.get().getClaimProperty(MULTI_VALUED_PROPERTY))) {
+            if (claimValue instanceof List) {
+                String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
+                for (String value : (List<String>) claimValue) {
+                    if (StringUtils.contains(value, multiAttributeSeparator)) {
+                        String errorMessage = String.format("The character %s is not allowed in claim values, as it " +
+                                        "is used internally to separate multiple values.", multiAttributeSeparator);
+                        DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
+                                "claims/" + claimKey, Availability.AVAILABLE, Validity.INVALID, errorMessage));
+                        throw new ActionExecutionResponseProcessorException(errorMessage);
+                    }
+                }
+                return;
             }
-        } else {
-            validateIfValueContainsMultiAttributeSeparator((String) claimValue);
-        }
-    }
 
-    private void validateIfValueContainsMultiAttributeSeparator(String value)
-            throws ActionExecutionResponseProcessorException {
-
-        if (StringUtils.contains(value, FrameworkUtils.getMultiAttributeSeparator())) {
-            String errorMessage = String.format("The character %s is not allowed in claim values, as it is " +
-                    "used internally to separate multiple values.", FrameworkUtils.getMultiAttributeSeparator());
+            String errorMessage = String.format("The claim value for the multi-valued attribute claim " + claimKey +
+                    " must be a list of values.");
             DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
-                    "claims", Availability.AVAILABLE, Validity.INVALID, errorMessage));
+                    "claims/" + claimKey, Availability.AVAILABLE, Validity.INVALID, errorMessage));
             throw new ActionExecutionResponseProcessorException(errorMessage);
+        } else {
+            if (!(claimValue instanceof String)) {
+                String errorMessage = "The claim value for the single-valued attribute claim " + claimKey +
+                        " must be a single value.";
+                DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
+                        "claims/" + claimKey, Availability.AVAILABLE, Validity.INVALID, errorMessage));
+                throw new ActionExecutionResponseProcessorException(errorMessage);
+            }
         }
     }
 
     private void resolveGroupsForFederatedUser(Map<ClaimMapping, String> claimMappings)
             throws ActionExecutionResponseProcessorException {
 
+        String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
         List<String> groupsFromResponse = userFromResponse.getUser().getGroups();
         if (groupsFromResponse != null) {
             if (groupsFromResponse.stream().anyMatch(
-                    groupName -> groupName.contains(FrameworkUtils.getMultiAttributeSeparator()))) {
+                    groupName -> groupName.contains(multiAttributeSeparator))) {
                 String errorMessage = String.format("The character %s is not allowed in names of groups, as it is " +
-                        "used internally to separate multiple groups.", FrameworkUtils.getMultiAttributeSeparator());
+                        "used internally to separate multiple groups.", multiAttributeSeparator);
                 DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
                         "groups", Availability.AVAILABLE, Validity.INVALID, errorMessage));
                 throw new ActionExecutionResponseProcessorException(errorMessage);
             }
-            claimMappings.put(buildClaimMapping(GROUP_CLAIM), String.join(
-                    FrameworkUtils.getMultiAttributeSeparator(), groupsFromResponse));
+            claimMappings.put(buildClaimMapping(GROUP_CLAIM), String.join(multiAttributeSeparator, groupsFromResponse));
         }
     }
 
@@ -348,5 +361,19 @@ public class AuthenticatedUserBuilder {
     private String getDefaultUserStore() {
 
         return (String) IdentityConfigParser.getInstance().getConfiguration().get(DEFAULT_USER_STORE_CONFIG_PATH);
+    }
+
+    private static Optional<LocalClaim> getLocalClaim(String claimKey, String tenantDomain) throws
+            ActionExecutionResponseProcessorException {
+
+        ClaimMetadataManagementService claimMetadataManagementService =
+                AuthenticatorAdapterDataHolder.getInstance().getClaimManagementService();
+
+        try {
+            return claimMetadataManagementService.getLocalClaim(claimKey, tenantDomain);
+        } catch (ClaimMetadataException e) {
+            throw new ActionExecutionResponseProcessorException(
+                    "Error while retrieving claim metadata for claim URI: " + claimKey, e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.exception.ClaimMetadataException;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -54,7 +55,6 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.DEFAULT_USER_STORE_CONFIG_PATH;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.EXTERNAL_ID_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_VALUED_PROPERTY;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ROLES_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.USERNAME_CLAIM;
 
@@ -216,7 +216,7 @@ public class AuthenticatedUserBuilder {
             throw new ActionExecutionResponseProcessorException("Claim not found for claim URI: " + claimKey);
         }
 
-        if (Boolean.parseBoolean(localClaim.get().getClaimProperty(MULTI_VALUED_PROPERTY))) {
+        if (Boolean.parseBoolean(localClaim.get().getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY))) {
             if (claimValue instanceof List) {
                 String multiAttributeSeparator = FrameworkUtils.getMultiAttributeSeparator();
                 for (String value : (List<String>) claimValue) {

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -36,7 +36,6 @@ import org.wso2.carbon.identity.action.execution.api.model.Organization;
 import org.wso2.carbon.identity.action.execution.api.model.Tenant;
 import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
-import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.AuthenticationRequestBuilder;
@@ -44,14 +43,15 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.compo
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticatingUser;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent;
+import org.wso2.carbon.identity.application.authenticator.adapter.util.MockServiceBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestFlowContextBuilder;
 import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
-import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.util.ArrayList;
@@ -64,10 +64,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.WSO2_CLAIM_DIALECT;
 import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder.AuthenticatedUserConstants;
+import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.ADDRESS_CLAIM;
 
 public class AuthenticationRequestBuilderTest {
 
@@ -76,6 +76,7 @@ public class AuthenticationRequestBuilderTest {
     private MockedStatic<FrameworkUtils> frameworkUtils;
     private MockedStatic<LoggerUtils> loggerUtils;
     private MockedStatic<OrganizationManagementUtil> organizationManagementUtil;
+    private static ClaimMetadataManagementService claimMetadataManagementService;
     private static final String SEPARATOR = ",";
 
     private static final String TENANT_DOMAIN_TEST = "carbon.super";
@@ -88,12 +89,13 @@ public class AuthenticationRequestBuilderTest {
     private static final String USER_MULTI_CLAIM_VALUE = "value1, value2";
     private static final String USER_GROUP_VALUE = "group1, group2";
     private static final String ADDRESS = "5th Avenue, New York, USA";
+    private static Map<ClaimMapping, String> userAttributes;
     Map<String, String> headers = Map.of("header-1", "value-1", "header-2", "value-2");
     Map<String, String> parameters = Map.of("param-1", "value-1", "param-2", "value-2");
     ArrayList<AuthHistory> authHistory;
 
     @BeforeClass
-    public void setUp() throws OrganizationManagementException {
+    public void setUp() throws Exception {
 
         authHistory = TestFlowContextBuilder.buildAuthHistory();
 
@@ -117,6 +119,10 @@ public class AuthenticationRequestBuilderTest {
         loggerUtils.when(() -> LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
 
         authenticationRequestBuilder = new AuthenticationRequestBuilder();
+        userAttributes = buildUserAttributes();
+        AuthenticatorAdapterDataHolder.getInstance().setClaimManagementService(
+                MockServiceBuilder.mockClaimMetadataManagementService(
+                        new ArrayList<>(userAttributes.keySet()), TENANT_DOMAIN_TEST));
     }
 
     @AfterClass
@@ -135,7 +141,7 @@ public class AuthenticationRequestBuilderTest {
     }
 
     @DataProvider
-    public Object[][] flowContextDataProvider() throws UserIdNotFoundException {
+    public Object[][] flowContextDataProvider() throws Exception {
 
         // Custom authenticator engaging in 1st step of authentication flow.
         FlowContext flowContextForNoUser = new TestFlowContextBuilder().buildFlowContext(
@@ -156,7 +162,7 @@ public class AuthenticationRequestBuilderTest {
         // Custom authenticator engaging in 2nd step of authentication flow with multi-value claims.
         AuthenticatedUser userWithMultiValueClaims = TestAuthenticatedTestUserBuilder.createAuthenticatedUser(
                 AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
-        userWithMultiValueClaims.setUserAttributes(buildUserAttributes());
+        userWithMultiValueClaims.setUserAttributes(userAttributes);
         FlowContext flowContextForUserWithMultiValueClaims = new TestFlowContextBuilder().buildFlowContext(
                 userWithMultiValueClaims, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
         AuthenticationRequestEvent expectedEventWithMultiValueClaims =
@@ -247,7 +253,7 @@ public class AuthenticationRequestBuilderTest {
     }
 
     private AuthenticationRequestEvent getExpectedEvent(AuthenticatedUser user, boolean isSubOrgFlow)
-            throws UserIdNotFoundException {
+            throws Exception {
 
         AuthenticationRequestEvent.Builder eventBuilder = new AuthenticationRequestEvent.Builder();
         eventBuilder.tenant(new Tenant(String.valueOf(TENANT_ID_TEST), TENANT_DOMAIN_TEST));
@@ -262,7 +268,7 @@ public class AuthenticationRequestBuilderTest {
         return eventBuilder.build();
     }
 
-    private static AuthenticatingUser createAuthenticatingUser(AuthenticatedUser user) throws UserIdNotFoundException {
+    private static AuthenticatingUser createAuthenticatingUser(AuthenticatedUser user) throws Exception {
 
         AuthenticatingUser authenticatingUser = new AuthenticatingUser(user.getUserId(), user);
         if (user.isFederatedUser()) {

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationResponseProcessorTest.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.Authe
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.component.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticatedUserData;
+import org.wso2.carbon.identity.application.authenticator.adapter.util.MockServiceBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestActionInvocationResponseBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestActionInvocationResponseBuilder.ExternallyAuthenticatedUser;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder;
@@ -88,8 +89,10 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.base.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.DEFAULT_USER_STORE_CONFIG_PATH;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.USERNAME_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.ADDRESS_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.USER_MULTI_VALUE_CLAIM_URI;
 
 public class AuthenticationResponseProcessorTest {
 
@@ -485,12 +488,13 @@ public class AuthenticationResponseProcessorTest {
 
         ExternallyAuthenticatedUser authUserWithInvalidMultiValueClaims = new ExternallyAuthenticatedUser();
         authUserWithInvalidMultiValueClaims.setClaims(new ArrayList<>(
-                List.of(new AuthenticatedUserData.Claim("claim1", "value1, value2"))));
+                List.of(new AuthenticatedUserData.Claim(USER_MULTI_VALUE_CLAIM_URI, "value1"))));
         ActionExecutionResponseContext<ActionInvocationSuccessResponse> authSuccessResponseWithInvalidMultiValueClaims =
                 TestActionInvocationResponseBuilder.buildAuthenticationSuccessResponse(
                         new ArrayList<>(), new AuthenticatedUserData(authUserWithInvalidMultiValueClaims));
         String errorMessageForInvalidMultiValueClaims =
-                "The character , is not allowed in claim values, as it is used internally to separate multiple values.";
+                "The claim value for the multi-valued attribute claim http://wso2.org/claims/multiValueUri " +
+                        "must be a list of values.";
 
 
         return new Object[][] {
@@ -614,6 +618,11 @@ public class AuthenticationResponseProcessorTest {
 
         when(mockedUserRealm.getUserStoreManager()).thenReturn(mockedUserStoreManager);
         when(mockedUserStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(abstractUserStoreManager);
+
+        List<ClaimMapping> allClaims = new ArrayList<>(expectedUserClaims().keySet());
+        allClaims.add(buildClaimMapping(USERNAME_CLAIM));
+        AuthenticatorAdapterDataHolder.getInstance().setClaimManagementService(
+                MockServiceBuilder.mockClaimMetadataManagementService(allClaims, TENANT_DOMAIN_TEST));
     }
 
     private void createExpectedAuthenticatedUsers() throws Exception {

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/MockServiceBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/MockServiceBuilder.java
@@ -1,0 +1,56 @@
+package org.wso2.carbon.identity.application.authenticator.adapter.util;
+
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_VALUED_PROPERTY;
+import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.USER_MULTI_VALUE_CLAIM_URI;
+
+public class MockServiceBuilder {
+
+    public static ClaimMetadataManagementService mockClaimMetadataManagementService(
+            List<ClaimMapping> userClaimUriList, String tenantDomain) throws Exception {
+
+        ClaimMetadataManagementService claimMetadataManagementService =
+                mock(ClaimMetadataManagementService.class);
+
+        for (ClaimMapping claimMapping : userClaimUriList) {
+            LocalClaim localClaim;
+            if (USER_MULTI_VALUE_CLAIM_URI.equals(claimMapping.getLocalClaim().getClaimUri()) ||
+                    GROUP_CLAIM.equals(claimMapping.getLocalClaim().getClaimUri())) {
+                localClaim = mockLocalMultiValuedClaim((claimMapping.getLocalClaim().getClaimUri()));
+            } else {
+                localClaim = mockLocalSingleValuedClaim((claimMapping.getLocalClaim().getClaimUri()));
+            }
+            when(claimMetadataManagementService.getLocalClaim(
+                    claimMapping.getLocalClaim().getClaimUri(), tenantDomain)
+            ).thenReturn(Optional.of(localClaim));
+        }
+        return claimMetadataManagementService;
+    }
+
+    private static LocalClaim mockLocalMultiValuedClaim(String claimUri) {
+
+        LocalClaim localClaim = mock(LocalClaim.class);
+        when(localClaim.getClaimURI()).thenReturn(claimUri);
+        when(localClaim.getClaimProperty(MULTI_VALUED_PROPERTY)).thenReturn("true");
+
+        return localClaim;
+    }
+
+    private static LocalClaim mockLocalSingleValuedClaim(String claimUri) {
+
+        LocalClaim localClaim = mock(LocalClaim.class);
+        when(localClaim.getClaimURI()).thenReturn(claimUri);
+        when(localClaim.getClaimProperty(MULTI_VALUED_PROPERTY)).thenReturn("false");
+
+        return localClaim;
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/MockServiceBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/MockServiceBuilder.java
@@ -1,8 +1,27 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.application.authenticator.adapter.util;
 
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.LocalClaim;
+import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +29,6 @@ import java.util.Optional;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.GROUP_CLAIM;
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.MULTI_VALUED_PROPERTY;
 import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.USER_MULTI_VALUE_CLAIM_URI;
 
 public class MockServiceBuilder {
@@ -40,7 +58,7 @@ public class MockServiceBuilder {
 
         LocalClaim localClaim = mock(LocalClaim.class);
         when(localClaim.getClaimURI()).thenReturn(claimUri);
-        when(localClaim.getClaimProperty(MULTI_VALUED_PROPERTY)).thenReturn("true");
+        when(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY)).thenReturn("true");
 
         return localClaim;
     }
@@ -49,7 +67,7 @@ public class MockServiceBuilder {
 
         LocalClaim localClaim = mock(LocalClaim.class);
         when(localClaim.getClaimURI()).thenReturn(claimUri);
-        when(localClaim.getClaimProperty(MULTI_VALUED_PROPERTY)).thenReturn("false");
+        when(localClaim.getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY)).thenReturn("false");
 
         return localClaim;
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestActionInvocationResponseBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestActionInvocationResponseBuilder.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants.ADDRESS_CLAIM;
+import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.ADDRESS_CLAIM;
 
 public class TestActionInvocationResponseBuilder {
 

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestAuthenticationAdapterConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestAuthenticationAdapterConstants.java
@@ -37,6 +37,7 @@ public class TestAuthenticationAdapterConstants {
         public static final String USER_MULTI_CLAIM_VALUE = "value1, value2";
         public static final String ADDRESS = "5th Avenue, New York, USA";
         public static final String SEPARATOR = ",";
+        public static final String ADDRESS_CLAIM = "http://wso2.org/claims/addresses";
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <version>${com.fasterxml.jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
         </identity.application.auth.adapter.package.export.version>
 
         <servlet-api.version>2.5</servlet-api.version>
-        <carbon.identity.framework.version>7.8.58</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.74</carbon.identity.framework.version>
         <testng.version>7.10.1</testng.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <mockito.version>5.3.1</mockito.version>


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/23408

With this PR:
- Improve multi-valued claim handling logic to be based on the metadata "multiValued" claim property instead of claim value.
Single valued:
```
"claims": [
        {
          "uri": "http://wso2.org/claims/emailaddress",
          "value": "bob@newdomain.com"
        }
      ],
```

Multi valued:
```
"claims": [
        {
          "uri": "http://wso2.org/claims/emailaddress",
          "value": ["bob@newdomain.com", "bob.work@domain.com"]
        }
      ],
```
- Validate claim uri sending from the external service are exists and claim value.