### PR TITLE
Populate headers and params in custom authenticator action request

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.identity.action.execution.api.model.Event;
 import org.wso2.carbon.identity.action.execution.api.model.FlowContext;
 import org.wso2.carbon.identity.action.execution.api.model.Operation;
 import org.wso2.carbon.identity.action.execution.api.model.Organization;
+import org.wso2.carbon.identity.action.execution.api.model.Request;
 import org.wso2.carbon.identity.action.execution.api.model.Tenant;
 import org.wso2.carbon.identity.action.execution.api.model.User;
 import org.wso2.carbon.identity.action.execution.api.model.UserStore;
@@ -41,6 +42,7 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.component.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticatingUser;
+import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent.AuthenticatedStep;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -51,6 +53,8 @@ import org.wso2.carbon.identity.organization.management.service.util.Organizatio
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * This is a builder class which is responsible for building authentication request payload which will be sent to the
@@ -74,19 +78,22 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
                                                               ActionExecutionRequestContext actionExecutionContext)
             throws ActionExecutionRequestBuilderException {
 
+        HttpServletRequest request = flowContext.getValue(
+                AuthenticatorAdapterConstants.AUTH_REQUEST, HttpServletRequest.class);
         AuthenticationContext context = flowContext.getValue(
                 AuthenticatorAdapterConstants.AUTH_CONTEXT, AuthenticationContext.class);
 
         ActionExecutionRequest.Builder actionRequestBuilder = new ActionExecutionRequest.Builder();
         actionRequestBuilder.flowId(context.getContextIdentifier());
         actionRequestBuilder.actionType(getSupportedActionType());
-        actionRequestBuilder.event(getEvent(context));
+        actionRequestBuilder.event(getEvent(request, context));
         actionRequestBuilder.allowedOperations(getAllowedOperations());
 
         return actionRequestBuilder.build();
     }
 
-    private Event getEvent(AuthenticationContext context) throws ActionExecutionRequestBuilderException {
+    private Event getEvent(HttpServletRequest request, AuthenticationContext context)
+            throws ActionExecutionRequestBuilderException {
 
         AuthenticatedUser currentAuthenticatedUser = context.getLastAuthenticatedUser();
 
@@ -100,6 +107,7 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
                 context.getServiceProviderName()));
         eventBuilder.currentStepIndex(context.getCurrentStep());
         eventBuilder.authenticatedSteps(getAuthenticatedStepsForEventBuilder(context));
+        eventBuilder.request(getRequest(request));
         return eventBuilder.build();
     }
 
@@ -158,5 +166,16 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
         AllowedOperation operation = new AllowedOperation();
         operation.setOp(Operation.REDIRECT);
         return Collections.singletonList(operation);
+    }
+
+    private Request getRequest(HttpServletRequest httpServletRequest) {
+
+        if (httpServletRequest == null) {
+            LOG.debug("HttpServletRequest is null. Additional headers and parameters will not be added to the " +
+                    "authentication request.");
+            return null;
+        }
+
+        return new AuthenticationRequest.Builder().fromHttpRequest(httpServletRequest).build();
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticationRequest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticationRequest.java
@@ -33,7 +33,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class AuthenticationRequest extends Request {
 
-    public AuthenticationRequest(Builder builder) {
+    private AuthenticationRequest(Builder builder) {
 
         additionalHeaders.addAll(builder.additionalHeaders);
         additionalParams.addAll(builder.additionalParams);

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticationRequest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticationRequest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.application.authenticator.adapter.internal.model;
+
+import org.wso2.carbon.identity.action.execution.api.model.Header;
+import org.wso2.carbon.identity.action.execution.api.model.Param;
+import org.wso2.carbon.identity.action.execution.api.model.Request;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * This class holds the authentication request object which is communicated to the external authentication service.
+ */
+public class AuthenticationRequest extends Request {
+
+    public AuthenticationRequest(Builder builder) {
+
+        additionalHeaders.addAll(builder.additionalHeaders);
+        additionalParams.addAll(builder.additionalParams);
+    }
+
+    /**
+     * Builder for the AuthenticationRequest.
+     */
+    public static class Builder {
+
+        private List<Header> additionalHeaders = new ArrayList<>();
+        private List<Param> additionalParams = new ArrayList<>();
+
+        public Builder additionalHeaders(List<Header> additionalHeaders) {
+
+            this.additionalHeaders = additionalHeaders;
+            return this;
+        }
+
+        public Builder additionalParams(List<Param> additionalParams) {
+
+            this.additionalParams = additionalParams;
+            return this;
+        }
+
+        public Builder fromHttpRequest(HttpServletRequest request) {
+
+            if (request != null) {
+                resolveHeaders(request);
+                resolveParams(request);
+            }
+            return this;
+        }
+
+        public AuthenticationRequest build() {
+
+            return new AuthenticationRequest(this);
+        }
+
+        private void resolveHeaders(HttpServletRequest request) {
+
+            Enumeration headerNames = request.getHeaderNames();
+            if (headerNames == null) {
+                return;
+            }
+
+            while (headerNames.hasMoreElements()) {
+                String headerName = (String) headerNames.nextElement();
+                Enumeration headerValues = request.getHeaders(headerName);
+                if (headerValues == null) {
+                    continue;
+                }
+
+                List<String> values = new ArrayList<>();
+                while (headerValues.hasMoreElements()) {
+                    values.add((String) headerValues.nextElement());
+                }
+                this.additionalHeaders.add(new Header(headerName, values.toArray(new String[0])));
+            }
+        }
+
+        private void resolveParams(HttpServletRequest request) {
+
+            Enumeration paramNames = request.getParameterNames();
+            if (paramNames == null) {
+                return;
+            }
+
+            while (paramNames.hasMoreElements()) {
+                String paramName = (String) paramNames.nextElement();
+                String[] paramValues = request.getParameterValues(paramName);
+                if (paramValues == null) {
+                    continue;
+                }
+                this.additionalParams.add(new Param(paramName, paramValues));
+            }
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -31,8 +31,11 @@ import org.wso2.carbon.identity.action.execution.api.model.AllowedOperation;
 import org.wso2.carbon.identity.action.execution.api.model.Application;
 import org.wso2.carbon.identity.action.execution.api.model.Event;
 import org.wso2.carbon.identity.action.execution.api.model.FlowContext;
+import org.wso2.carbon.identity.action.execution.api.model.Header;
 import org.wso2.carbon.identity.action.execution.api.model.Operation;
 import org.wso2.carbon.identity.action.execution.api.model.Organization;
+import org.wso2.carbon.identity.action.execution.api.model.Param;
+import org.wso2.carbon.identity.action.execution.api.model.Request;
 import org.wso2.carbon.identity.action.execution.api.model.Tenant;
 import org.wso2.carbon.identity.action.execution.api.model.UserClaim;
 import org.wso2.carbon.identity.application.authentication.framework.context.AuthHistory;
@@ -42,6 +45,7 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.Authe
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.component.AuthenticatorAdapterDataHolder;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.constant.AuthenticatorAdapterConstants;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticatingUser;
+import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.MockServiceBuilder;
 import org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder;
@@ -58,6 +62,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -76,6 +81,9 @@ public class AuthenticationRequestBuilderTest {
     private MockedStatic<FrameworkUtils> frameworkUtils;
     private MockedStatic<LoggerUtils> loggerUtils;
     private MockedStatic<OrganizationManagementUtil> organizationManagementUtil;
+    private AuthenticatedUser localUser;
+    private AuthenticatedUser fedUser;
+    private AuthenticatedUser userWithMultiValueClaims;
     private static ClaimMetadataManagementService claimMetadataManagementService;
     private static final String SEPARATOR = ",";
 
@@ -123,6 +131,14 @@ public class AuthenticationRequestBuilderTest {
         AuthenticatorAdapterDataHolder.getInstance().setClaimManagementService(
                 MockServiceBuilder.mockClaimMetadataManagementService(
                         new ArrayList<>(userAttributes.keySet()), TENANT_DOMAIN_TEST));
+
+        localUser = TestAuthenticatedTestUserBuilder
+                .createAuthenticatedUser(AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
+        fedUser = TestAuthenticatedTestUserBuilder
+                .createAuthenticatedUser(AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
+        userWithMultiValueClaims = TestAuthenticatedTestUserBuilder
+                .createAuthenticatedUser(AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
+        userWithMultiValueClaims.setUserAttributes(userAttributes);
     }
 
     @AfterClass
@@ -143,39 +159,33 @@ public class AuthenticationRequestBuilderTest {
     @DataProvider
     public Object[][] flowContextDataProvider() throws Exception {
 
-        // Custom authenticator engaging in 1st step of authentication flow.
-        FlowContext flowContextForNoUser = new TestFlowContextBuilder().buildFlowContext(
-                 null, SUPER_TENANT_DOMAIN_NAME, headers, parameters, new ArrayList<>());
-
-        // Custom authenticator engaging in 2nd step of authentication flow with Local authenticated user.
-        AuthenticatedUser localUser = TestAuthenticatedTestUserBuilder.createAuthenticatedUser(
-                AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
-        FlowContext flowContextForLocalUser = new TestFlowContextBuilder().buildFlowContext(
-                localUser, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
-
-        // Custom authenticator engaging in 2nd step of authentication flow with federated authenticated user.
-        AuthenticatedUser fedUser = TestAuthenticatedTestUserBuilder.createAuthenticatedUser(
-                AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
-        FlowContext flowContextForFedUser = new TestFlowContextBuilder().buildFlowContext(
-                fedUser, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
-
-        // Custom authenticator engaging in 2nd step of authentication flow with multi-value claims.
-        AuthenticatedUser userWithMultiValueClaims = TestAuthenticatedTestUserBuilder.createAuthenticatedUser(
-                AuthenticatedUserConstants.LOCAL_USER_PREFIX, SUPER_TENANT_DOMAIN_NAME);
-        userWithMultiValueClaims.setUserAttributes(userAttributes);
-        FlowContext flowContextForUserWithMultiValueClaims = new TestFlowContextBuilder().buildFlowContext(
-                userWithMultiValueClaims, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
         AuthenticationRequestEvent expectedEventWithMultiValueClaims =
                 getExpectedEvent(userWithMultiValueClaims, false);
 
         return new Object[][]{
-                {flowContextForNoUser, getExpectedEvent(null, true), true},
-                {flowContextForNoUser, getExpectedEvent(null, false), false},
-                {flowContextForLocalUser, getExpectedEvent(localUser, true), true},
-                {flowContextForLocalUser, getExpectedEvent(localUser, false), false},
-                {flowContextForFedUser, getExpectedEvent(fedUser, true), true},
-                {flowContextForFedUser, getExpectedEvent(fedUser, false), false},
-                {flowContextForUserWithMultiValueClaims, expectedEventWithMultiValueClaims, false}};
+                // Custom authenticator engaging in 1st step of authentication flow.
+                {getFlowContextForNoUser(), getExpectedEvent(null, true), true},
+                {getFlowContextForNoUser(), getExpectedEvent(null, false), false},
+                // Custom authenticator engaging in 2nd step of authentication flow with Local authenticated user.
+                {getFlowContextForUser(localUser), getExpectedEvent(localUser, true), true},
+                {getFlowContextForUser(localUser), getExpectedEvent(localUser, false), false},
+                // Custom authenticator engaging in 2nd step of authentication flow with federated authenticated user.
+                {getFlowContextForUser(fedUser), getExpectedEvent(fedUser, true), true},
+                {getFlowContextForUser(fedUser), getExpectedEvent(fedUser, false), false},
+                // Custom authenticator engaging in 2nd step of authentication flow with multi-value claims.
+                {getFlowContextForUser(userWithMultiValueClaims), expectedEventWithMultiValueClaims, false}};
+    }
+
+    private FlowContext getFlowContextForNoUser() {
+
+        return new TestFlowContextBuilder().buildFlowContext(
+                null, SUPER_TENANT_DOMAIN_NAME, headers, parameters, new ArrayList<>());
+    }
+
+    private FlowContext getFlowContextForUser(AuthenticatedUser user) {
+
+        return new TestFlowContextBuilder().buildFlowContext(
+                user, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
     }
 
     @Test(dataProvider = "flowContextDataProvider")
@@ -199,7 +209,7 @@ public class AuthenticationRequestBuilderTest {
         Assert.assertTrue(actualEvent instanceof AuthenticationRequestEvent);
         AuthenticationRequestEvent actualAuthenticationEvent = (AuthenticationRequestEvent) actualEvent;
 
-        Assert.assertNull(actualAuthenticationEvent.getRequest());
+        assertRequest(actualAuthenticationEvent.getRequest(), expectedEvent.getRequest());
         Assert.assertEquals(actualAuthenticationEvent.getTenant().getId(), expectedEvent.getTenant().getId());
         Assert.assertEquals(actualAuthenticationEvent.getApplication().getId(), expectedEvent.getApplication().getId());
         Assert.assertEquals(actualAuthenticationEvent.getApplication().getName(),
@@ -246,6 +256,34 @@ public class AuthenticationRequestBuilderTest {
         Assert.assertEquals(actualAuthenticationEvent.getAuthenticatedSteps().length, authHistory.size());
     }
 
+    private void assertRequest(Request actualRequest, Request expectedRequest) {
+
+        Assert.assertTrue(actualRequest instanceof AuthenticationRequest);
+        AuthenticationRequest actualAuthRequest = (AuthenticationRequest) actualRequest;
+
+        Assert.assertEquals(actualAuthRequest.getAdditionalHeaders().size(), this.headers.size());
+        Assert.assertEquals(actualAuthRequest.getAdditionalParams().size(), this.parameters.size());
+        for (Header expectedHeader : expectedRequest.getAdditionalHeaders()) {
+            Header actualHeader = actualAuthRequest.getAdditionalHeaders().stream()
+                    .filter(h -> h.getName().equals(expectedHeader.getName()))
+                    .findFirst().orElse(null);
+
+            Assert.assertNotNull(actualHeader);
+            Assert.assertEquals(actualHeader.getValue().length, expectedHeader.getValue().length);
+            Assert.assertEquals(actualHeader.getValue()[0], expectedHeader.getValue()[0]);
+        }
+
+        for (Param expectedParam : expectedRequest.getAdditionalParams()) {
+            Param actualParam = actualAuthRequest.getAdditionalParams().stream()
+                    .filter(p -> p.getName().equals(expectedParam.getName()))
+                    .findFirst().orElse(null);
+
+            Assert.assertNotNull(actualParam);
+            Assert.assertEquals(actualParam.getValue().length, expectedParam.getValue().length);
+            Assert.assertEquals(actualParam.getValue()[0], expectedParam.getValue()[0]);
+        }
+    }
+
     private void assertAllowedOperations(List<AllowedOperation> allowedOperationList) {
 
         Assert.assertEquals(allowedOperationList.size(), 1);
@@ -264,6 +302,14 @@ public class AuthenticationRequestBuilderTest {
         if (user != null) {
             eventBuilder.user(createAuthenticatingUser(user));
         }
+        eventBuilder.request(new AuthenticationRequest.Builder()
+                .additionalHeaders(this.headers.entrySet().stream()
+                        .map(e -> new Header(e.getKey(), new String[]{e.getValue()}))
+                        .collect(Collectors.toList()))
+                .additionalParams(this.parameters.entrySet().stream()
+                        .map(e -> new Param(e.getKey(), new String[]{e.getValue()}))
+                        .collect(Collectors.toList()))
+                .build());
 
         return eventBuilder.build();
     }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestFlowContextBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestFlowContextBuilder.java
@@ -178,8 +178,9 @@ public class TestFlowContextBuilder {
         Enumeration<String> parameterEnumeration = Collections.enumeration(parameters.keySet());
         when(request.getHeaderNames()).thenReturn(headerEnumeration);
         when(request.getParameterNames()).thenReturn(parameterEnumeration);
-        headers.forEach((key, value) -> when(request.getHeader(key)).thenReturn(value));
-        parameters.forEach((key, value) -> when(request.getParameter(key)).thenReturn(value));
+        headers.forEach((key, value) -> when(request.getHeaders(key))
+                .thenReturn(Collections.enumeration(Collections.singletonList(value))));
+        parameters.forEach((key, value) -> when(request.getParameterValues(key)).thenReturn(new String[]{value}));
         return request;
     }
 }


### PR DESCRIPTION
## Purpose
> This PR will improve on setting request headers and parameters to the custom authenticator action request payload.

Adding back the changes reverted with following PR including few improvements
- https://github.com/wso2-extensions/identity-outbound-auth-adapter/pull/22 

### Related Issue
- 