### PR TITLE
Refactor tenant and organization resolving logic with Identity Context

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
@@ -156,8 +156,7 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
                     .build());
 
             if (minimalOrg.getDepth() > 0) {
-                // If the depth is greater than 0, it is a sub-organization.
-                // Hence, need to resolve the root tenant domain.
+                // If the depth is greater than 0, it is a sub-organization. Resolving the root tenant domain.
                 tenantDomain = OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(tenantDomain);
             }
             eventBuilder.tenant(new Tenant(String.valueOf(IdentityTenantUtil.getTenantId(tenantDomain)), tenantDomain));

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.application.authenticator.adapter.internal;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
@@ -45,9 +46,12 @@ import org.wso2.carbon.identity.application.authenticator.adapter.internal.model
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequest;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent;
 import org.wso2.carbon.identity.application.authenticator.adapter.internal.model.AuthenticationRequestEvent.AuthenticatedStep;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.RootOrganization;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.util.ArrayList;
@@ -126,27 +130,68 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
             throws ActionExecutionRequestBuilderException {
 
         String tenantDomain = context.getTenantDomain();
+        Tenant tenant = getTenantFromIdentityContext();
+        Organization organization = getOrganizationFromIdentityContext();
 
+        if (tenant != null && organization != null && StringUtils.equals(tenantDomain, organization.getOrgHandle())) {
+            eventBuilder.tenant(tenant);
+            eventBuilder.organization(organization);
+            return;
+        }
+
+        // Fallback logic to resolve tenant and organization information when not available in the identity context.
         try {
-            /* Only if the user is attempting to log in to a sub-organization, the organization will be set,
-             and also the root tenant will be considered the tenant domain. */
-            if (OrganizationManagementUtil.isOrganization(tenantDomain)) {
-                String orgId = organizationManager.resolveOrganizationId(tenantDomain);
-                eventBuilder.organization(new Organization(
-                        orgId,
-                        organizationManager.getOrganizationNameById(orgId)
-                ));
-                tenantDomain = OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(orgId);
+            String orgId = organizationManager.resolveOrganizationId(tenantDomain);
+            MinimalOrganization minimalOrg = organizationManager.getMinimalOrganization(orgId, tenantDomain);
+            if (minimalOrg == null) {
+                throw new ActionExecutionRequestBuilderException(
+                        "Unable to find organization information for the tenant: " + tenantDomain);
             }
+
+            eventBuilder.organization(new Organization.Builder()
+                    .id(minimalOrg.getId())
+                    .name(minimalOrg.getName())
+                    .orgHandle(minimalOrg.getOrganizationHandle())
+                    .depth(minimalOrg.getDepth())
+                    .build());
+
+            if (minimalOrg.getDepth() > 0) {
+                // If the depth is greater than 0, it is a sub-organization.
+                // Hence, need to resolve the root tenant domain.
+                tenantDomain = OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(tenantDomain);
+            }
+            eventBuilder.tenant(new Tenant(String.valueOf(IdentityTenantUtil.getTenantId(tenantDomain)), tenantDomain));
         } catch (OrganizationManagementException e) {
             throw new ActionExecutionRequestBuilderException(String.format("Error occurred while retrieving " +
                     "organization details for the tenant %s in authentication context.", tenantDomain), e);
         }
+    }
 
-        eventBuilder.tenant(new Tenant(
-                String.valueOf(IdentityTenantUtil.getTenantId(tenantDomain)),
-                tenantDomain
-        ));
+    private Tenant getTenantFromIdentityContext() {
+
+        RootOrganization rootOrganization = IdentityContext.getThreadLocalIdentityContext().getRootOrganization();
+        if (rootOrganization == null) {
+            return null;
+        }
+
+        return new Tenant(String.valueOf(rootOrganization.getAssociatedTenantId()),
+                rootOrganization.getAssociatedTenantDomain());
+    }
+
+    private Organization getOrganizationFromIdentityContext() {
+
+        org.wso2.carbon.identity.core.context.model.Organization organization =
+                IdentityContext.getThreadLocalIdentityContext().getOrganization();
+        if (organization == null) {
+            return null;
+        }
+
+        return new Organization.Builder()
+                .id(organization.getId())
+                .name(organization.getName())
+                .orgHandle(organization.getOrganizationHandle())
+                .depth(organization.getDepth())
+                .build();
     }
 
     private AuthenticatedStep[] getAuthenticatedStepsForEventBuilder(AuthenticationContext context) {

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -21,10 +21,10 @@ package org.wso2.carbon.identity.application.authenticator.adapter;
 import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.action.execution.api.exception.ActionExecutionRequestBuilderException;
 import org.wso2.carbon.identity.action.execution.api.model.ActionExecutionRequest;
 import org.wso2.carbon.identity.action.execution.api.model.ActionType;
 import org.wso2.carbon.identity.action.execution.api.model.AllowedOperation;
@@ -53,9 +53,12 @@ import org.wso2.carbon.identity.application.authenticator.adapter.util.TestFlowC
 import org.wso2.carbon.identity.application.common.model.Claim;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
-import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
+import org.wso2.carbon.identity.common.testng.WithCarbonHome;
+import org.wso2.carbon.identity.core.context.IdentityContext;
+import org.wso2.carbon.identity.core.context.model.RootOrganization;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.model.MinimalOrganization;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.util.ArrayList;
@@ -74,6 +77,7 @@ import static org.wso2.carbon.identity.application.authenticator.adapter.interna
 import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticatedTestUserBuilder.AuthenticatedUserConstants;
 import static org.wso2.carbon.identity.application.authenticator.adapter.util.TestAuthenticationAdapterConstants.AuthenticatingUserConstants.ADDRESS_CLAIM;
 
+@WithCarbonHome
 public class AuthenticationRequestBuilderTest {
 
     private AuthenticationRequestBuilder authenticationRequestBuilder;
@@ -81,16 +85,19 @@ public class AuthenticationRequestBuilderTest {
     private MockedStatic<FrameworkUtils> frameworkUtils;
     private MockedStatic<LoggerUtils> loggerUtils;
     private MockedStatic<OrganizationManagementUtil> organizationManagementUtil;
+    private OrganizationManager organizationManager;
     private AuthenticatedUser localUser;
     private AuthenticatedUser fedUser;
     private AuthenticatedUser userWithMultiValueClaims;
-    private static ClaimMetadataManagementService claimMetadataManagementService;
     private static final String SEPARATOR = ",";
 
+    private static final String ROOT_ORG_ID_TEST = "10084a8d-113f-4211-a0d5-efe36b082211";
     private static final String TENANT_DOMAIN_TEST = "carbon.super";
     private static final int TENANT_ID_TEST = -1234;
     private static final String ORG_NAME_TEST = "subOrg";
-    private static final String ORG_ID_TEST = "12345";
+    private static final String ORG_HANDLE_TEST = "subOrg.com";
+    private static final String ORG_ID_TEST = "550e8400-e29b-41d4-a716-446655440000";
+    private static final int ORG_DEPTH_TEST = 1;
     private static final String USER_CLAIM_URI = WSO2_CLAIM_DIALECT + "/customUri";
     private static final String USER_CLAIM_VALUE = "customValue";
     private static final String USER_MULTI_VALUE_CLAIM_URI = WSO2_CLAIM_DIALECT + "/multiValueUri";
@@ -107,9 +114,7 @@ public class AuthenticationRequestBuilderTest {
 
         authHistory = TestFlowContextBuilder.buildAuthHistory();
 
-        OrganizationManager organizationManager = mock(OrganizationManager.class);
-        when(organizationManager.resolveOrganizationId(anyString())).thenReturn(ORG_ID_TEST);
-        when(organizationManager.getOrganizationNameById(anyString())).thenReturn(ORG_NAME_TEST);
+        organizationManager = mock(OrganizationManager.class);
         AuthenticatorAdapterDataHolder.getInstance().setOrganizationManager(organizationManager);
 
         identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
@@ -119,12 +124,9 @@ public class AuthenticationRequestBuilderTest {
         frameworkUtils.when(FrameworkUtils::getMultiAttributeSeparator).thenReturn(SEPARATOR);
 
         organizationManagementUtil = mockStatic(OrganizationManagementUtil.class);
-        organizationManagementUtil.when(() ->
-                        OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(anyString()))
-                .thenReturn(TENANT_DOMAIN_TEST);
 
         loggerUtils = mockStatic(LoggerUtils.class);
-        loggerUtils.when(() -> LoggerUtils.isDiagnosticLogsEnabled()).thenReturn(true);
+        loggerUtils.when(LoggerUtils::isDiagnosticLogsEnabled).thenReturn(true);
 
         authenticationRequestBuilder = new AuthenticationRequestBuilder();
         userAttributes = buildUserAttributes();
@@ -150,50 +152,129 @@ public class AuthenticationRequestBuilderTest {
         loggerUtils.close();
     }
 
+    @AfterMethod
+    public void end() {
+
+        IdentityContext.destroyCurrentContext();
+    }
+
     @Test
     public void testGetSupportedActionType() {
 
         Assert.assertEquals(authenticationRequestBuilder.getSupportedActionType(), ActionType.AUTHENTICATION);
     }
 
-    @DataProvider
-    public Object[][] flowContextDataProvider() throws Exception {
+    private FlowContext getFlowContextForNoUser(String tenantDomain) {
 
-        AuthenticationRequestEvent expectedEventWithMultiValueClaims =
-                getExpectedEvent(userWithMultiValueClaims, false);
+        return new TestFlowContextBuilder().buildFlowContext(
+                null, tenantDomain, headers, parameters, new ArrayList<>());
+    }
+
+    private FlowContext getFlowContextForUser(AuthenticatedUser user, String tenantDomain) {
+
+        return new TestFlowContextBuilder().buildFlowContext(
+                user, tenantDomain, headers, parameters, authHistory);
+    }
+
+    @DataProvider
+    public Object[][] requestBuilderDataProvider() {
 
         return new Object[][]{
                 // Custom authenticator engaging in 1st step of authentication flow.
-                {getFlowContextForNoUser(), getExpectedEvent(null, true), true},
-                {getFlowContextForNoUser(), getExpectedEvent(null, false), false},
+                {getFlowContextForNoUser(TENANT_DOMAIN_TEST), null},
                 // Custom authenticator engaging in 2nd step of authentication flow with Local authenticated user.
-                {getFlowContextForUser(localUser), getExpectedEvent(localUser, true), true},
-                {getFlowContextForUser(localUser), getExpectedEvent(localUser, false), false},
+                {getFlowContextForUser(localUser, TENANT_DOMAIN_TEST), localUser},
                 // Custom authenticator engaging in 2nd step of authentication flow with federated authenticated user.
-                {getFlowContextForUser(fedUser), getExpectedEvent(fedUser, true), true},
-                {getFlowContextForUser(fedUser), getExpectedEvent(fedUser, false), false},
+                {getFlowContextForUser(fedUser, TENANT_DOMAIN_TEST), fedUser},
                 // Custom authenticator engaging in 2nd step of authentication flow with multi-value claims.
-                {getFlowContextForUser(userWithMultiValueClaims), expectedEventWithMultiValueClaims, false}};
+                {getFlowContextForUser(userWithMultiValueClaims, TENANT_DOMAIN_TEST), userWithMultiValueClaims}};
     }
 
-    private FlowContext getFlowContextForNoUser() {
+    @Test(dataProvider = "requestBuilderDataProvider")
+    public void testBuildActionExecutionRequest(FlowContext flowContext, AuthenticatedUser user) throws Exception {
 
-        return new TestFlowContextBuilder().buildFlowContext(
-                null, SUPER_TENANT_DOMAIN_NAME, headers, parameters, new ArrayList<>());
+        AuthenticationRequestEvent expectedEvent = getExpectedEvent(user, false);
+        IdentityContext.getThreadLocalIdentityContext().setRootOrganization(new RootOrganization.Builder()
+                .organizationId(ROOT_ORG_ID_TEST)
+                .associatedTenantDomain(TENANT_DOMAIN_TEST)
+                .associatedTenantId(TENANT_ID_TEST)
+                .build());
+        IdentityContext.getThreadLocalIdentityContext().setOrganization(
+                new org.wso2.carbon.identity.core.context.model.Organization.Builder()
+                    .id(ROOT_ORG_ID_TEST)
+                    .name(TENANT_DOMAIN_TEST)
+                    .organizationHandle(TENANT_DOMAIN_TEST)
+                    .depth(0)
+                    .build());
+
+        ActionExecutionRequest actionExecutionRequest =
+                authenticationRequestBuilder.buildActionExecutionRequest(flowContext, null);
+        Assert.assertNotNull(actionExecutionRequest);
+        Assert.assertEquals(actionExecutionRequest.getFlowId(), TestFlowContextBuilder.FLOW_ID);
+        Assert.assertEquals(actionExecutionRequest.getActionType(), ActionType.AUTHENTICATION);
+        assertEvent(actionExecutionRequest.getEvent(), expectedEvent);
+        assertAllowedOperations(actionExecutionRequest.getAllowedOperations());
     }
 
-    private FlowContext getFlowContextForUser(AuthenticatedUser user) {
+    @DataProvider
+    public Object[][] requestBuilderSubOrgDataProvider() {
 
-        return new TestFlowContextBuilder().buildFlowContext(
-                user, SUPER_TENANT_DOMAIN_NAME, headers, parameters, authHistory);
+        return new Object[][]{
+                // Custom authenticator engaging in 1st step of authentication flow.
+                {getFlowContextForNoUser(ORG_HANDLE_TEST), null},
+                // Custom authenticator engaging in 2nd step of authentication flow with Local authenticated user.
+                {getFlowContextForUser(localUser, ORG_HANDLE_TEST), localUser},
+                // Custom authenticator engaging in 2nd step of authentication flow with federated authenticated user.
+                {getFlowContextForUser(fedUser, ORG_HANDLE_TEST), fedUser},
+                // Custom authenticator engaging in 2nd step of authentication flow with multi-value claims.
+                {getFlowContextForUser(userWithMultiValueClaims, ORG_HANDLE_TEST), userWithMultiValueClaims}};
     }
 
-    @Test(dataProvider = "flowContextDataProvider")
-    public void testBuildActionExecutionRequest(FlowContext flowContext, AuthenticationRequestEvent expectedEvent,
-                                                boolean isSubOrgFlow) throws ActionExecutionRequestBuilderException {
+    @Test(dataProvider = "requestBuilderSubOrgDataProvider")
+    public void testBuildActionExecutionRequestForSubOrg(FlowContext flowContext, AuthenticatedUser user)
+            throws Exception {
 
-        organizationManagementUtil.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
-                .thenReturn(isSubOrgFlow);
+        AuthenticationRequestEvent expectedEvent = getExpectedEvent(user, true);
+        IdentityContext.getThreadLocalIdentityContext().setRootOrganization(new RootOrganization.Builder()
+                .organizationId(ROOT_ORG_ID_TEST)
+                .associatedTenantDomain(TENANT_DOMAIN_TEST)
+                .associatedTenantId(TENANT_ID_TEST)
+                .build());
+        IdentityContext.getThreadLocalIdentityContext().setOrganization(
+                new org.wso2.carbon.identity.core.context.model.Organization.Builder()
+                        .id(ORG_ID_TEST)
+                        .name(ORG_NAME_TEST)
+                        .organizationHandle(ORG_HANDLE_TEST)
+                        .depth(ORG_DEPTH_TEST)
+                        .build());
+
+        ActionExecutionRequest actionExecutionRequest =
+                authenticationRequestBuilder.buildActionExecutionRequest(flowContext, null);
+        Assert.assertNotNull(actionExecutionRequest);
+        Assert.assertEquals(actionExecutionRequest.getFlowId(), TestFlowContextBuilder.FLOW_ID);
+        Assert.assertEquals(actionExecutionRequest.getActionType(), ActionType.AUTHENTICATION);
+        assertEvent(actionExecutionRequest.getEvent(), expectedEvent);
+        assertAllowedOperations(actionExecutionRequest.getAllowedOperations());
+    }
+
+
+    @Test(dataProvider = "requestBuilderSubOrgDataProvider")
+    public void testBuildActionExecutionRequestWithResolvingOrgInternally(FlowContext flowContext,
+                                                                          AuthenticatedUser user) throws Exception {
+
+        AuthenticationRequestEvent expectedEvent = getExpectedEvent(user, true);
+        when(organizationManager.resolveOrganizationId(anyString())).thenReturn(ORG_ID_TEST);
+        when(organizationManager.getMinimalOrganization(anyString(), anyString())).thenReturn(
+                new MinimalOrganization.Builder()
+                        .id(ORG_ID_TEST)
+                        .name(ORG_NAME_TEST)
+                        .organizationHandle(ORG_HANDLE_TEST)
+                        .depth(ORG_DEPTH_TEST)
+                        .build());
+        when(organizationManager.getOrganizationNameById(anyString())).thenReturn(ORG_NAME_TEST);
+        organizationManagementUtil.when(() ->
+                        OrganizationManagementUtil.getRootOrgTenantDomainBySubOrgTenantDomain(anyString()))
+                .thenReturn(TENANT_DOMAIN_TEST);
 
         ActionExecutionRequest actionExecutionRequest =
                 authenticationRequestBuilder.buildActionExecutionRequest(flowContext, null);
@@ -297,7 +378,19 @@ public class AuthenticationRequestBuilderTest {
         eventBuilder.tenant(new Tenant(String.valueOf(TENANT_ID_TEST), TENANT_DOMAIN_TEST));
         eventBuilder.application(new Application(TestFlowContextBuilder.SP_ID, TestFlowContextBuilder.SP_NAME));
         if (isSubOrgFlow) {
-            eventBuilder.organization(new Organization(ORG_ID_TEST, ORG_NAME_TEST));
+            eventBuilder.organization(new Organization.Builder()
+                    .id(ORG_ID_TEST)
+                    .name(ORG_NAME_TEST)
+                    .orgHandle(ORG_HANDLE_TEST)
+                    .depth(ORG_DEPTH_TEST)
+                    .build());
+        } else {
+            eventBuilder.organization(new Organization.Builder()
+                    .id(ROOT_ORG_ID_TEST)
+                    .name(TENANT_DOMAIN_TEST)
+                    .orgHandle(TENANT_DOMAIN_TEST)
+                    .depth(0)
+                    .build());
         }
         if (user != null) {
             eventBuilder.user(createAuthenticatingUser(user));

--- a/pom.xml
+++ b/pom.xml
@@ -326,14 +326,14 @@
         </identity.application.auth.adapter.package.export.version>
 
         <servlet-api.version>2.5</servlet-api.version>
-        <carbon.identity.framework.version>7.8.74</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.335</carbon.identity.framework.version>
         <testng.version>7.10.1</testng.version>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <mockito.version>5.3.1</mockito.version>
         <mockito-testng.version>0.5.2</mockito-testng.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
-        <identity.organization.management.core.version>1.1.24</identity.organization.management.core.version>
-        <carbon.kernel.version>4.10.10</carbon.kernel.version>
+        <identity.organization.management.core.version>1.1.46</identity.organization.management.core.version>
+        <carbon.kernel.version>4.10.33</carbon.kernel.version>
         <junit.version>4.13.1</junit.version>
         <com.fasterxml.jackson.version>2.16.1</com.fasterxml.jackson.version>
 


### PR DESCRIPTION
## Purpose
- With the improvement done through https://github.com/wso2/product-is/issues/24864, the tenant and organization information is available in the Identity Context in the runtime.
- Hence we can utilize those values without consuming additional DB queries to fetch organization and tenant related information.
- However kept the previous logic as a fallback mechanism to resolve tenant and organization when the data in the IdentityContext is empty.
- In that fallback logic, used newly introduces method via https://github.com/wso2/product-is/issues/24855, where the data fetching is optimized with caching with improved information(organization handle and depth).


### New payload
```json
{
  "actionType": "AUTHENTICATION",
  "flowId": "06dfd555-a35b-4418-b20a-c45eaadc0e19",
  "event": {
    "request": {
      "additionalHeaders": [
        {
          "name": "host",
          "value": [
            "localhost:9443"
          ]
        }
      ],
      "additionalParams": [
        {
          "name": "sessionDataKey",
          "value": [
            "06dfd555-a35b-4418-b20a-c45eaadc0e19"
          ]
        }
      ]
    },
    "tenant": {
      "id": "1",
      "name": "wso2.com"
    },
    "organization": {
      "id": "3f175cab-627a-48e8-9487-52eeeb650d86",
      "name": "sub",
      "orgHandle": "suborg",
      "depth": 1
    },
    "application": {
      "id": "0fa76f1d-740d-433e-b668-cb994d0be2f0",
      "name": "test"
    },
    "currentStepIndex": 1
  },
  "allowedOperations": [
    {
      "op": "redirect"
    }
  ],
  "requestId": "f3b5f202-9de8-4872-8789-d84a00725d4d"
}
```


### Related Issue
- https://github.com/wso2/product-is/issues/25872