### PR TITLE
Improve custom authenticators for passing allow parameters

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/AuthenticationRequestBuilder.java
@@ -111,7 +111,7 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
                 context.getServiceProviderName()));
         eventBuilder.currentStepIndex(context.getCurrentStep());
         eventBuilder.authenticatedSteps(getAuthenticatedStepsForEventBuilder(context));
-        eventBuilder.request(getRequest(request));
+        eventBuilder.request(getRequest(request, context));
         return eventBuilder.build();
     }
 
@@ -212,7 +212,7 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
         return Collections.singletonList(operation);
     }
 
-    private Request getRequest(HttpServletRequest httpServletRequest) {
+    private Request getRequest(HttpServletRequest httpServletRequest, AuthenticationContext context) {
 
         if (httpServletRequest == null) {
             LOG.debug("HttpServletRequest is null. Additional headers and parameters will not be added to the " +
@@ -220,6 +220,9 @@ public class AuthenticationRequestBuilder implements ActionExecutionRequestBuild
             return null;
         }
 
-        return new AuthenticationRequest.Builder().fromHttpRequest(httpServletRequest).build();
+        return new AuthenticationRequest.Builder()
+                .fromHttpRequest(httpServletRequest)
+                .fromInitialAuthorizeRequest(context.getQueryParams())
+                .build();
     }
 }

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticationRequest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/model/AuthenticationRequest.java
@@ -68,6 +68,26 @@ public class AuthenticationRequest extends Request {
             return this;
         }
 
+        /**
+         * Extract query parameters from the initial request query string.
+         *
+         * @param queryParamString Query parameter string from the initial request.
+         * @return Builder instance.
+         */
+        public Builder fromInitialAuthorizeRequest(String queryParamString) {
+
+            if (queryParamString != null && !queryParamString.isEmpty()) {
+                String[] paramPairs = queryParamString.split("&");
+                for (String pair : paramPairs) {
+                    String[] keyValue = pair.split("=");
+                    String key = keyValue[0];
+                    String value = keyValue.length > 1 ? keyValue[1] : "";
+                    this.additionalParams.add(new Param(key, new String[]{value}));
+                }
+            }
+            return this;
+        }
+
         public AuthenticationRequest build() {
 
             return new AuthenticationRequest(this);

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/AuthenticationRequestBuilderTest.java
@@ -106,7 +106,8 @@ public class AuthenticationRequestBuilderTest {
     private static final String ADDRESS = "5th Avenue, New York, USA";
     private static Map<ClaimMapping, String> userAttributes;
     Map<String, String> headers = Map.of("header-1", "value-1", "header-2", "value-2");
-    Map<String, String> parameters = Map.of("param-1", "value-1", "param-2", "value-2");
+    Map<String, String> parametersFromRequest = Map.of("param-1", "value-1", "param-2", "value-2");
+    Map<String, String> parametersFromAuthorizeRequest = Map.of("testQuery", "123", "sample", "abc");
     ArrayList<AuthHistory> authHistory;
 
     @BeforeClass
@@ -167,13 +168,13 @@ public class AuthenticationRequestBuilderTest {
     private FlowContext getFlowContextForNoUser(String tenantDomain) {
 
         return new TestFlowContextBuilder().buildFlowContext(
-                null, tenantDomain, headers, parameters, new ArrayList<>());
+                null, tenantDomain, headers, parametersFromRequest, new ArrayList<>());
     }
 
     private FlowContext getFlowContextForUser(AuthenticatedUser user, String tenantDomain) {
 
         return new TestFlowContextBuilder().buildFlowContext(
-                user, tenantDomain, headers, parameters, authHistory);
+                user, tenantDomain, headers, parametersFromRequest, authHistory);
     }
 
     @DataProvider
@@ -343,7 +344,16 @@ public class AuthenticationRequestBuilderTest {
         AuthenticationRequest actualAuthRequest = (AuthenticationRequest) actualRequest;
 
         Assert.assertEquals(actualAuthRequest.getAdditionalHeaders().size(), this.headers.size());
-        Assert.assertEquals(actualAuthRequest.getAdditionalParams().size(), this.parameters.size());
+        Assert.assertEquals(actualAuthRequest.getAdditionalParams().size(),
+                this.parametersFromRequest.size() + this.parametersFromAuthorizeRequest.size());
+        for (Map.Entry<String, String> paramEntry : this.parametersFromAuthorizeRequest.entrySet()) {
+            Param actualParam = actualAuthRequest.getAdditionalParams().stream()
+                    .filter(p -> p.getName().equals(paramEntry.getKey()))
+                    .findFirst().orElse(null);
+
+            Assert.assertNotNull(actualParam);
+            Assert.assertEquals(actualParam.getValue()[0], paramEntry.getValue());
+        }
         for (Header expectedHeader : expectedRequest.getAdditionalHeaders()) {
             Header actualHeader = actualAuthRequest.getAdditionalHeaders().stream()
                     .filter(h -> h.getName().equals(expectedHeader.getName()))
@@ -399,7 +409,7 @@ public class AuthenticationRequestBuilderTest {
                 .additionalHeaders(this.headers.entrySet().stream()
                         .map(e -> new Header(e.getKey(), new String[]{e.getValue()}))
                         .collect(Collectors.toList()))
-                .additionalParams(this.parameters.entrySet().stream()
+                .additionalParams(this.parametersFromRequest.entrySet().stream()
                         .map(e -> new Param(e.getKey(), new String[]{e.getValue()}))
                         .collect(Collectors.toList()))
                 .build());

--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestFlowContextBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/test/java/org/wso2/carbon/identity/application/authenticator/adapter/util/TestFlowContextBuilder.java
@@ -148,6 +148,7 @@ public class TestFlowContextBuilder {
         authenticationContext.setAuthenticatorProperties(new HashMap<String, String>() {{
             put(AuthenticatorAdapterConstants.ACTION_ID_CONFIG, ACTION_ID);
         }});
+        authenticationContext.setQueryParams("testQuery=123&sample=abc");
         return authenticationContext;
     }
 


### PR DESCRIPTION
Issue:
- https://github.com/wso2/product-is/issues/26605

With this PR, support the ability to use parameters sent in the initial authorization request, in addition to parameters from the /commonauth request.