### PR TITLE
Add missing diagnostic log for claim-not-found validation

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.adapter/src/main/java/org/wso2/carbon/identity/application/authenticator/adapter/internal/util/AuthenticatedUserBuilder.java
@@ -213,7 +213,10 @@ public class AuthenticatedUserBuilder {
             throws ActionExecutionResponseProcessorException {
 
         if (!localClaim.isPresent()) {
-            throw new ActionExecutionResponseProcessorException("Claim not found for claim URI: " + claimKey);
+            String errorMessage = "Claim not found for claim URI: " + claimKey;
+            DiagnosticLogger.logSuccessResponseDataValidationError(new AuthenticationActionExecutionResult(
+                    "claims/" + claimKey, Availability.AVAILABLE, Validity.INVALID, errorMessage));
+            throw new ActionExecutionResponseProcessorException(errorMessage);
         }
 
         if (Boolean.parseBoolean(localClaim.get().getClaimProperty(ClaimConstants.MULTI_VALUED_PROPERTY))) {


### PR DESCRIPTION
## Purpose

Adds the missing diagnostic log in `AuthenticatedUserBuilder.validateClaimValue()` for the claim-not-found branch.

Previously, when a claim URI in the authentication action response could not be resolved to a local claim, the method threw `ActionExecutionResponseProcessorException` **without** emitting a diagnostic log. This was inconsistent with every other validation branch in the same method (multi-valued separator violation, wrong list type, wrong single-value type), all of which call `DiagnosticLogger.logSuccessResponseDataValidationError(...)` before throwing.

## Change

Emit a data-validation diagnostic log for field `claims/<claimURI>` before throwing, matching the existing pattern.

## Related issue
- https://github.com/wso2/product-is/issues/28123

🤖 Generated with [Claude Code](https://claude.com/claude-code)